### PR TITLE
fix: podcast episodes now filter under podcast type and use consisten…

### DIFF
--- a/app/api/og/[shareToken]/route.tsx
+++ b/app/api/og/[shareToken]/route.tsx
@@ -295,6 +295,7 @@ function getTypeGradient(type: string): string {
     case 'book':
       return 'linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%)';
     case 'podcast':
+    case 'podcast_episode':
       return 'linear-gradient(135deg, #8b5cf6 0%, #6d28d9 100%)';
     case 'music':
       return 'linear-gradient(135deg, #22c55e 0%, #16a34a 100%)';

--- a/app/api/og/landing/route.tsx
+++ b/app/api/og/landing/route.tsx
@@ -272,6 +272,7 @@ function getTypeGradient(type: string): string {
     case 'book':
       return 'linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%)';
     case 'podcast':
+    case 'podcast_episode':
       return 'linear-gradient(135deg, #8b5cf6 0%, #6d28d9 100%)';
     case 'music':
       return 'linear-gradient(135deg, #22c55e 0%, #16a34a 100%)';

--- a/components/shelf/ItemCard.tsx
+++ b/components/shelf/ItemCard.tsx
@@ -26,7 +26,7 @@ export function ItemCard({ item, onClick, editMode, onDelete, onEditNote }: Item
     book: 'bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200',
     podcast: 'bg-purple-100 dark:bg-purple-900/50 text-purple-800 dark:text-purple-200',
     music: 'bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200',
-    podcast_episode: 'bg-orange-100 dark:bg-orange-900/50 text-orange-800 dark:text-orange-200',
+    podcast_episode: 'bg-purple-100 dark:bg-purple-900/50 text-purple-800 dark:text-purple-200',
   };
 
   return (

--- a/components/shelf/ItemModal.tsx
+++ b/components/shelf/ItemModal.tsx
@@ -95,10 +95,10 @@ export function ItemModal({ item, isOpen, onClose }: ItemModalProps) {
               <div className="mb-3 sm:mb-4">
                 <span className={`inline-block px-2.5 py-1 text-xs font-medium rounded-full ${
                   item.type === 'book' ? 'bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200' :
-                  item.type === 'podcast' ? 'bg-purple-100 dark:bg-purple-900/50 text-purple-800 dark:text-purple-200' :
+                  item.type === 'podcast' || item.type === 'podcast_episode' ? 'bg-purple-100 dark:bg-purple-900/50 text-purple-800 dark:text-purple-200' :
                   'bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200'
                 }`}>
-                  {item.type}
+                  {item.type === 'podcast_episode' ? 'podcast episode' : item.type}
                 </span>
               </div>
 

--- a/components/shelf/ShelfGrid.tsx
+++ b/components/shelf/ShelfGrid.tsx
@@ -185,13 +185,16 @@ interface ShelfGridProps {
 export function ShelfGrid({ items, onItemClick, editMode, onDeleteItem, onEditNote }: ShelfGridProps) {
   const [selectedType, setSelectedType] = useState<ItemType | 'all'>('all');
 
-  const filteredItems =
-    selectedType === 'all' ? items : items.filter((item) => item.type === selectedType);
+  const filteredItems = selectedType === 'all' 
+    ? items 
+    : selectedType === 'podcast'
+    ? items.filter((item) => item.type === 'podcast' || item.type === 'podcast_episode')
+    : items.filter((item) => item.type === selectedType);
 
   const counts = {
     all: items.length,
     book: items.filter((i) => i.type === 'book').length,
-    podcast: items.filter((i) => i.type === 'podcast').length,
+    podcast: items.filter((i) => i.type === 'podcast' || i.type === 'podcast_episode').length,
     music: items.filter((i) => i.type === 'music').length,
   };
 

--- a/components/shelf/Top5ItemCard.tsx
+++ b/components/shelf/Top5ItemCard.tsx
@@ -46,7 +46,7 @@ export function Top5ItemCard({
     book: 'bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200',
     podcast: 'bg-purple-100 dark:bg-purple-900/50 text-purple-800 dark:text-purple-200',
     music: 'bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200',
-    podcast_episode: 'bg-orange-100 dark:bg-orange-900/50 text-orange-800 dark:text-orange-200',
+    podcast_episode: 'bg-purple-100 dark:bg-purple-900/50 text-purple-800 dark:text-purple-200',
   };
 
   // Gold gradient for rank badge


### PR DESCRIPTION
…t purple styling

- Updated ShelfGrid filtering logic to include podcast_episode items when filtering by 'podcast'
- Fixed podcast_episode count to be included in podcast filter count
- Updated ItemModal to show purple styling for podcast_episode (same as podcast)
- Fixed ItemCard and Top5ItemCard to use purple styling for podcast_episode instead of orange
- Updated OG image generation to handle podcast_episode with same gradient as podcast
- All tests passing, build successful

Closes #64