### PR TITLE
feat: close item modal on browser back button (mobile + desktop)

### DIFF
--- a/components/shelf/ItemModal.tsx
+++ b/components/shelf/ItemModal.tsx
@@ -46,6 +46,9 @@ function NoteSection({ notes, className = 'mb-4' }: NoteSectionProps) {
 export function ItemModal({ item, isOpen, onClose }: ItemModalProps) {
   // Track whether we pushed a history entry so we know whether to pop it on close
   const pushedHistoryEntry = useRef(false);
+  // Stable ref so effects don't re-run when the parent passes a new inline arrow function
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
 
   useEffect(() => {
     if (isOpen) {
@@ -62,7 +65,7 @@ export function ItemModal({ item, isOpen, onClose }: ItemModalProps) {
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        onClose();
+        onCloseRef.current();
       }
     };
 
@@ -73,7 +76,7 @@ export function ItemModal({ item, isOpen, onClose }: ItemModalProps) {
     return () => {
       document.removeEventListener('keydown', handleEscape);
     };
-  }, [isOpen, onClose]);
+  }, [isOpen]);
 
   // Push a history entry when the modal opens so the back button closes it
   useEffect(() => {
@@ -83,7 +86,7 @@ export function ItemModal({ item, isOpen, onClose }: ItemModalProps) {
 
       const handlePopState = () => {
         pushedHistoryEntry.current = false;
-        onClose();
+        onCloseRef.current();
       };
 
       window.addEventListener('popstate', handlePopState);
@@ -97,7 +100,7 @@ export function ItemModal({ item, isOpen, onClose }: ItemModalProps) {
         }
       };
     }
-  }, [isOpen, onClose]);
+  }, [isOpen]);
 
   // Image fit handling state
   const [imageError, setImageError] = useState(false);

--- a/components/shelf/ItemModal.tsx
+++ b/components/shelf/ItemModal.tsx
@@ -2,7 +2,7 @@
 import Image from 'next/image';
 
 import { Item } from '@/lib/types/shelf';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { extractVideoId } from '@/lib/api/youtube';
 import { StarDisplay } from '@/components/ui/StarDisplay';
 import { getAspectRatio, getAspectRatioNumeric } from '@/lib/constants/aspectRatios';
@@ -48,7 +48,9 @@ export function ItemModal({ item, isOpen, onClose }: ItemModalProps) {
   const pushedHistoryEntry = useRef(false);
   // Stable ref so effects don't re-run when the parent passes a new inline arrow function
   const onCloseRef = useRef(onClose);
-  onCloseRef.current = onClose;
+  useLayoutEffect(() => {
+    onCloseRef.current = onClose;
+  });
 
   useEffect(() => {
     if (isOpen) {

--- a/components/shelf/ItemModal.tsx
+++ b/components/shelf/ItemModal.tsx
@@ -2,7 +2,7 @@
 import Image from 'next/image';
 
 import { Item } from '@/lib/types/shelf';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { extractVideoId } from '@/lib/api/youtube';
 import { StarDisplay } from '@/components/ui/StarDisplay';
 import { getAspectRatio, getAspectRatioNumeric } from '@/lib/constants/aspectRatios';
@@ -44,6 +44,9 @@ function NoteSection({ notes, className = 'mb-4' }: NoteSectionProps) {
 }
 
 export function ItemModal({ item, isOpen, onClose }: ItemModalProps) {
+  // Track whether we pushed a history entry so we know whether to pop it on close
+  const pushedHistoryEntry = useRef(false);
+
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = 'hidden';
@@ -70,6 +73,30 @@ export function ItemModal({ item, isOpen, onClose }: ItemModalProps) {
     return () => {
       document.removeEventListener('keydown', handleEscape);
     };
+  }, [isOpen, onClose]);
+
+  // Push a history entry when the modal opens so the back button closes it
+  useEffect(() => {
+    if (isOpen) {
+      history.pushState({ itemModal: true }, '');
+      pushedHistoryEntry.current = true;
+
+      const handlePopState = () => {
+        pushedHistoryEntry.current = false;
+        onClose();
+      };
+
+      window.addEventListener('popstate', handlePopState);
+      return () => {
+        window.removeEventListener('popstate', handlePopState);
+        // If the modal is closing without the back button (e.g. backdrop click,
+        // Escape key), pop the history entry we pushed so the URL stays clean
+        if (pushedHistoryEntry.current) {
+          pushedHistoryEntry.current = false;
+          history.back();
+        }
+      };
+    }
   }, [isOpen, onClose]);
 
   // Image fit handling state


### PR DESCRIPTION
Pushes a history entry when the modal opens. The popstate event (fired by the back button on mobile/desktop) closes the modal instead of navigating away. Normal closes (backdrop, Escape, X button) pop the history entry to keep the URL clean.