### PR TITLE
Improve shelf OG image: reliability, caching, visuals

### DIFF
--- a/app/api/og/[shareToken]/route.tsx
+++ b/app/api/og/[shareToken]/route.tsx
@@ -1,21 +1,20 @@
 import { ImageResponse } from '@vercel/og';
 import { getShelfByShareToken, getItemsByShelfId } from '@/lib/db/queries';
 import { createLogger } from '@/lib/utils/logger';
+import type { Item, ItemType } from '@/lib/types/shelf';
 
 const logger = createLogger('OGImage');
 
 export const runtime = 'edge';
 
-/**
- * Generate Open Graph image for shared shelves
- * 
- * This creates a beautiful preview image showing:
- * - Shelf name
- * - Book/podcast/music covers on a shelf
- * - Branding
- * 
- * Used when sharing shelf links on LinkedIn, Twitter, etc.
- */
+const WIDTH = 1200;
+const HEIGHT = 630;
+const MAX_ITEMS = 5;
+const IMAGE_FETCH_TIMEOUT_MS = 2500;
+const CACHE_CONTROL = 'public, max-age=300, s-maxage=3600, stale-while-revalidate=86400';
+
+type PreparedItem = Item & { image_data: string | null };
+
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ shareToken: string }> }
@@ -23,42 +22,28 @@ export async function GET(
   try {
     const { shareToken } = await params;
 
-    // Fetch shelf data
     const shelf = await getShelfByShareToken(shareToken);
     if (!shelf || !shelf.is_public) {
-      // Return a fallback image for missing/private shelves
-      return new ImageResponse(
-        (
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: '100%',
-              height: '100%',
-              background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-              fontFamily: 'system-ui, sans-serif',
-            }}
-          >
-            <div style={{ display: 'flex', alignItems: 'center', gap: '16px', marginBottom: '24px' }}>
-              <BookshelfIcon />
-              <span style={{ fontSize: '48px', fontWeight: 'bold', color: 'white' }}>
-                Virtual Bookshelf
-              </span>
-            </div>
-            <p style={{ fontSize: '24px', color: 'rgba(255,255,255,0.8)' }}>
-              Curate and share your favorites
-            </p>
-          </div>
-        ),
-        { width: 1200, height: 630 }
-      );
+      return fallbackImage();
     }
 
-    // Get shelf items
     const items = await getItemsByShelfId(shelf.id);
-    const displayItems = items.slice(0, 5); // Show up to 5 items
+
+    const lastModified = items.reduce<Date>(
+      (max, item) => (item.updated_at > max ? item.updated_at : max),
+      shelf.updated_at
+    );
+    const etag = `W/"${lastModified.getTime()}-${items.length}"`;
+
+    if (request.headers.get('if-none-match') === etag) {
+      return new Response(null, {
+        status: 304,
+        headers: { ETag: etag, 'Cache-Control': CACHE_CONTROL },
+      });
+    }
+
+    const displayItems = items.slice(0, MAX_ITEMS);
+    const prepared = await prefetchCovers(displayItems);
 
     return new ImageResponse(
       (
@@ -73,137 +58,56 @@ export async function GET(
             padding: '48px',
           }}
         >
-          {/* Header */}
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '32px' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
               <BookshelfIcon />
-              <span style={{ fontSize: '24px', fontWeight: '600', color: '#1f2937' }}>
+              <span style={{ fontSize: '24px', fontWeight: 600, color: '#1f2937' }}>
                 Virtual Bookshelf
               </span>
             </div>
           </div>
 
-          {/* Shelf Title */}
-          <h1 style={{ 
-            fontSize: '56px', 
-            fontWeight: 'bold', 
-            color: '#111827', 
+          <h1 style={{
+            fontSize: '56px',
+            fontWeight: 800,
+            color: '#111827',
             margin: '0 0 16px 0',
             lineHeight: 1.1,
+            letterSpacing: '-0.02em',
+            maxWidth: '1000px',
           }}>
-            {shelf.name}
+            {truncate(shelf.name, 60)}
           </h1>
 
-          {/* Description (if exists) */}
           {shelf.description && (
-            <p style={{ 
-              fontSize: '24px', 
-              color: '#6b7280', 
+            <p style={{
+              fontSize: '24px',
+              color: '#6b7280',
               margin: '0 0 32px 0',
-              maxWidth: '800px',
+              maxWidth: '900px',
               lineHeight: 1.4,
             }}>
-              {shelf.description.length > 100 
-                ? shelf.description.substring(0, 100) + '...' 
-                : shelf.description}
+              {truncate(shelf.description, 110)}
             </p>
           )}
 
-          {/* Shelf with items */}
           <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'flex-end' }}>
-            {/* Items Row */}
-            <div style={{ 
-              display: 'flex', 
-              alignItems: 'flex-end', 
-              gap: '20px', 
+            <div style={{
+              display: 'flex',
+              alignItems: 'flex-end',
+              gap: '20px',
               paddingLeft: '24px',
               paddingRight: '24px',
-              paddingBottom: '0',
             }}>
-              {displayItems.length > 0 ? (
-                displayItems.map((item) => (
-                  <div 
-                    key={item.id} 
-                    style={{ 
-                      display: 'flex', 
-                      flexDirection: 'column',
-                      alignItems: 'center',
-                    }}
-                  >
-                    {/* Book cover */}
-                    <div style={{
-                      display: 'flex',
-                      width: '140px',
-                      height: '200px',
-                      borderRadius: '4px',
-                      overflow: 'hidden',
-                      boxShadow: '0 4px 12px rgba(0,0,0,0.15), 0 2px 4px rgba(0,0,0,0.1)',
-                      background: item.image_url ? 'transparent' : getTypeGradient(item.type),
-                    }}>
-                      {item.image_url ? (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img
-                          src={item.image_url}
-                          alt={item.title}
-                          style={{
-                            width: '100%',
-                            height: '100%',
-                            objectFit: 'cover',
-                          }}
-                        />
-                      ) : (
-                        <div style={{
-                          display: 'flex',
-                          flexDirection: 'column',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          width: '100%',
-                          height: '100%',
-                          padding: '12px',
-                          color: 'white',
-                        }}>
-                          <span style={{ fontSize: '14px', fontWeight: '600', textAlign: 'center', lineHeight: 1.2 }}>
-                            {item.title.length > 30 ? item.title.substring(0, 30) + '...' : item.title}
-                          </span>
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                ))
+              {prepared.length > 0 ? (
+                prepared.map((item) => <Cover key={item.id} item={item} />)
               ) : (
-                <div style={{ 
-                  display: 'flex', 
-                  alignItems: 'center', 
-                  justifyContent: 'center',
-                  width: '100%',
-                  height: '200px',
-                  color: '#9ca3af',
-                  fontSize: '20px',
-                }}>
-                  Empty shelf - add some items!
-                </div>
+                <EmptyState />
               )}
-              
-              {/* Show "+X more" if there are more items */}
-              {items.length > 5 && (
-                <div style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  width: '100px',
-                  height: '200px',
-                  background: 'rgba(0,0,0,0.05)',
-                  borderRadius: '4px',
-                  color: '#6b7280',
-                  fontSize: '20px',
-                  fontWeight: '600',
-                }}>
-                  +{items.length - 5} more
-                </div>
-              )}
+
+              {items.length > MAX_ITEMS && <MoreTile count={items.length - MAX_ITEMS} />}
             </div>
 
-            {/* Shelf Bar */}
             <div style={{
               display: 'flex',
               width: '100%',
@@ -214,60 +118,228 @@ export async function GET(
             }} />
           </div>
 
-          {/* Footer */}
-          <div style={{ 
-            display: 'flex', 
-            alignItems: 'center', 
+          <div style={{
+            display: 'flex',
+            alignItems: 'center',
             justifyContent: 'space-between',
             marginTop: '24px',
           }}>
             <span style={{ fontSize: '18px', color: '#9ca3af' }}>
               {items.length} {items.length === 1 ? 'item' : 'items'}
             </span>
-            <span style={{ fontSize: '18px', color: '#6b7280', fontWeight: '500' }}>
+            <span style={{ fontSize: '18px', color: '#6b7280', fontWeight: 500 }}>
               virtualbookshelf.app
             </span>
           </div>
         </div>
       ),
-      { width: 1200, height: 630 }
+      {
+        width: WIDTH,
+        height: HEIGHT,
+        headers: { 'Cache-Control': CACHE_CONTROL, ETag: etag },
+      }
     );
   } catch (error) {
     logger.errorWithException('Failed to generate OG image', error);
-    
-    // Return fallback image on error
-    return new ImageResponse(
-      (
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            width: '100%',
-            height: '100%',
-            background: 'linear-gradient(135deg, #1f2937 0%, #111827 100%)',
-            fontFamily: 'system-ui, sans-serif',
-          }}
-        >
-          <div style={{ display: 'flex', alignItems: 'center', gap: '16px', marginBottom: '24px' }}>
-            <BookshelfIcon />
-            <span style={{ fontSize: '48px', fontWeight: 'bold', color: 'white' }}>
-              Virtual Bookshelf
-            </span>
-          </div>
-          <p style={{ fontSize: '24px', color: 'rgba(255,255,255,0.7)' }}>
-            Curate and share your favorites
-          </p>
-        </div>
-      ),
-      { width: 1200, height: 630 }
-    );
+    return fallbackImage();
   }
 }
 
-// Helper function to get gradient based on item type
-function getTypeGradient(type: string): string {
+function Cover({ item }: { item: PreparedItem }) {
+  const { width, height } = getCoverDimensions(item.type);
+  const showImage = item.image_data !== null;
+
+  return (
+    <div style={{
+      display: 'flex',
+      width: `${width}px`,
+      height: `${height}px`,
+      borderRadius: '4px',
+      overflow: 'hidden',
+      boxShadow: '0 4px 12px rgba(0,0,0,0.15), 0 2px 4px rgba(0,0,0,0.1)',
+      background: showImage ? '#fff' : getTypeGradient(item.type),
+    }}>
+      {showImage ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={item.image_data!}
+          alt={item.title}
+          style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+        />
+      ) : (
+        <div style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '100%',
+          height: '100%',
+          padding: '12px',
+          color: 'white',
+          gap: '10px',
+        }}>
+          <TypeIcon type={item.type} />
+          <span style={{ fontSize: '14px', fontWeight: 600, textAlign: 'center', lineHeight: 1.2 }}>
+            {truncate(item.title, 30)}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MoreTile({ count }: { count: number }) {
+  return (
+    <div style={{
+      display: 'flex',
+      position: 'relative',
+      width: '120px',
+      height: '200px',
+    }}>
+      <div style={{
+        display: 'flex',
+        position: 'absolute',
+        top: '8px',
+        left: '8px',
+        width: '104px',
+        height: '184px',
+        background: 'rgba(0,0,0,0.06)',
+        borderRadius: '4px',
+      }} />
+      <div style={{
+        display: 'flex',
+        position: 'absolute',
+        top: '4px',
+        left: '4px',
+        width: '104px',
+        height: '184px',
+        background: 'rgba(0,0,0,0.10)',
+        borderRadius: '4px',
+      }} />
+      <div style={{
+        display: 'flex',
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '104px',
+        height: '184px',
+        background: 'linear-gradient(135deg, #4b5563 0%, #1f2937 100%)',
+        borderRadius: '4px',
+        boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}>
+        <span style={{ fontSize: '32px', fontWeight: 700, color: 'white' }}>+{count}</span>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: '100%',
+      height: '200px',
+      color: '#9ca3af',
+      fontSize: '20px',
+    }}>
+      Empty shelf — add some items!
+    </div>
+  );
+}
+
+function fallbackImage() {
+  return new ImageResponse(
+    (
+      <div style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: '100%',
+        height: '100%',
+        background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        fontFamily: 'system-ui, sans-serif',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '16px', marginBottom: '24px' }}>
+          <BookshelfIcon />
+          <span style={{ fontSize: '48px', fontWeight: 'bold', color: 'white' }}>
+            Virtual Bookshelf
+          </span>
+        </div>
+        <p style={{ fontSize: '24px', color: 'rgba(255,255,255,0.8)' }}>
+          Curate and share your favorites
+        </p>
+      </div>
+    ),
+    {
+      width: WIDTH,
+      height: HEIGHT,
+      headers: { 'Cache-Control': 'public, max-age=60, s-maxage=300' },
+    }
+  );
+}
+
+async function prefetchCovers(items: Item[]): Promise<PreparedItem[]> {
+  return Promise.all(
+    items.map(async (item) => ({
+      ...item,
+      image_data: item.image_url ? await fetchAsDataUrl(item.image_url) : null,
+    }))
+  );
+}
+
+async function fetchAsDataUrl(url: string): Promise<string | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), IMAGE_FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { Accept: 'image/*' },
+    });
+    if (!res.ok) return null;
+    const buffer = await res.arrayBuffer();
+    const contentType = res.headers.get('content-type') || 'image/jpeg';
+    if (!contentType.startsWith('image/')) return null;
+    return `data:${contentType};base64,${uint8ToBase64(new Uint8Array(buffer))}`;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function uint8ToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode.apply(null, Array.from(bytes.subarray(i, i + chunk)));
+  }
+  return btoa(binary);
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? text.substring(0, max).trimEnd() + '…' : text;
+}
+
+function getCoverDimensions(type: ItemType): { width: number; height: number } {
+  switch (type) {
+    case 'music':
+    case 'podcast':
+    case 'podcast_episode':
+    case 'video':
+      return { width: 180, height: 180 };
+    case 'book':
+      return { width: 140, height: 200 };
+    default:
+      return { width: 160, height: 200 };
+  }
+}
+
+function getTypeGradient(type: ItemType): string {
   switch (type) {
     case 'book':
       return 'linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%)';
@@ -276,12 +348,66 @@ function getTypeGradient(type: string): string {
       return 'linear-gradient(135deg, #8b5cf6 0%, #6d28d9 100%)';
     case 'music':
       return 'linear-gradient(135deg, #22c55e 0%, #16a34a 100%)';
+    case 'video':
+      return 'linear-gradient(135deg, #ef4444 0%, #b91c1c 100%)';
+    case 'stock':
+      return 'linear-gradient(135deg, #f59e0b 0%, #b45309 100%)';
     default:
       return 'linear-gradient(135deg, #6b7280 0%, #4b5563 100%)';
   }
 }
 
-// SVG Components for the OG image
+function TypeIcon({ type }: { type: ItemType }) {
+  const size = 32;
+  const stroke = 'rgba(255,255,255,0.9)';
+  switch (type) {
+    case 'book':
+      return (
+        <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={stroke} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+          <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+        </svg>
+      );
+    case 'podcast':
+    case 'podcast_episode':
+      return (
+        <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={stroke} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="9" y="2" width="6" height="12" rx="3" />
+          <path d="M5 10v2a7 7 0 0 0 14 0v-2" />
+          <line x1="12" y1="19" x2="12" y2="22" />
+        </svg>
+      );
+    case 'music':
+      return (
+        <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={stroke} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M9 18V5l12-2v13" />
+          <circle cx="6" cy="18" r="3" />
+          <circle cx="18" cy="16" r="3" />
+        </svg>
+      );
+    case 'video':
+      return (
+        <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={stroke} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polygon points="5 3 19 12 5 21 5 3" />
+        </svg>
+      );
+    case 'stock':
+      return (
+        <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={stroke} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="3 17 9 11 13 15 21 7" />
+          <polyline points="14 7 21 7 21 14" />
+        </svg>
+      );
+    default:
+      return (
+        <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={stroke} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+        </svg>
+      );
+  }
+}
+
 function BookshelfIcon() {
   return (
     <svg width="48" height="48" viewBox="0 0 24 24" fill="#1f2937">

--- a/app/api/og/[shareToken]/route.tsx
+++ b/app/api/og/[shareToken]/route.tsx
@@ -1,6 +1,7 @@
 import { ImageResponse } from '@vercel/og';
 import { getShelfByShareToken, getItemsByShelfId } from '@/lib/db/queries';
 import { createLogger } from '@/lib/utils/logger';
+import { fetchAsDataUrl, OG_CACHE_CONTROL } from '@/lib/og/imageLoader';
 import type { Item, ItemType } from '@/lib/types/shelf';
 
 const logger = createLogger('OGImage');
@@ -10,8 +11,6 @@ export const runtime = 'edge';
 const WIDTH = 1200;
 const HEIGHT = 630;
 const MAX_ITEMS = 5;
-const IMAGE_FETCH_TIMEOUT_MS = 2500;
-const CACHE_CONTROL = 'public, max-age=300, s-maxage=3600, stale-while-revalidate=86400';
 
 type PreparedItem = Item & { image_data: string | null };
 
@@ -38,7 +37,7 @@ export async function GET(
     if (request.headers.get('if-none-match') === etag) {
       return new Response(null, {
         status: 304,
-        headers: { ETag: etag, 'Cache-Control': CACHE_CONTROL },
+        headers: { ETag: etag, 'Cache-Control': OG_CACHE_CONTROL },
       });
     }
 
@@ -136,7 +135,7 @@ export async function GET(
       {
         width: WIDTH,
         height: HEIGHT,
-        headers: { 'Cache-Control': CACHE_CONTROL, ETag: etag },
+        headers: { 'Cache-Control': OG_CACHE_CONTROL, ETag: etag },
       }
     );
   } catch (error) {
@@ -290,35 +289,6 @@ async function prefetchCovers(items: Item[]): Promise<PreparedItem[]> {
       image_data: item.image_url ? await fetchAsDataUrl(item.image_url) : null,
     }))
   );
-}
-
-async function fetchAsDataUrl(url: string): Promise<string | null> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), IMAGE_FETCH_TIMEOUT_MS);
-  try {
-    const res = await fetch(url, {
-      signal: controller.signal,
-      headers: { Accept: 'image/*' },
-    });
-    if (!res.ok) return null;
-    const buffer = await res.arrayBuffer();
-    const contentType = res.headers.get('content-type') || 'image/jpeg';
-    if (!contentType.startsWith('image/')) return null;
-    return `data:${contentType};base64,${uint8ToBase64(new Uint8Array(buffer))}`;
-  } catch {
-    return null;
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-function uint8ToBase64(bytes: Uint8Array): string {
-  let binary = '';
-  const chunk = 0x8000;
-  for (let i = 0; i < bytes.length; i += chunk) {
-    binary += String.fromCharCode.apply(null, Array.from(bytes.subarray(i, i + chunk)));
-  }
-  return btoa(binary);
 }
 
 function truncate(text: string, max: number): string {

--- a/app/api/og/landing/route.tsx
+++ b/app/api/og/landing/route.tsx
@@ -1,9 +1,12 @@
 import { ImageResponse } from '@vercel/og';
 import { getPublicShelvesByUserId, getItemsByShelfId, getShelfByShareToken } from '@/lib/db/queries';
 import { getDemoUserId, getDemoShelfToken } from '@/lib/utils/env';
+import { fetchAsDataUrl, OG_CACHE_CONTROL } from '@/lib/og/imageLoader';
 import { Item } from '@/lib/types/shelf';
 
 export const runtime = 'edge';
+
+type PreparedItem = Item & { image_data: string | null };
 
 /**
  * Fetch demo items for the OG image
@@ -51,10 +54,29 @@ async function getDemoItems(): Promise<Item[]> {
  * 
  * Used when sharing the main site on LinkedIn, Twitter, etc.
  */
-export async function GET() {
-  // Fetch real demo items
+export async function GET(request: Request) {
   const demoItems = await getDemoItems();
   const hasRealItems = demoItems.length > 0;
+
+  const lastModified = demoItems.reduce<number>(
+    (max, item) => Math.max(max, item.updated_at.getTime()),
+    0
+  );
+  const etag = `W/"landing-${lastModified}-${demoItems.length}"`;
+
+  if (request.headers.get('if-none-match') === etag) {
+    return new Response(null, {
+      status: 304,
+      headers: { ETag: etag, 'Cache-Control': OG_CACHE_CONTROL },
+    });
+  }
+
+  const prepared: PreparedItem[] = await Promise.all(
+    demoItems.map(async (item) => ({
+      ...item,
+      image_data: item.image_url ? await fetchAsDataUrl(item.image_url) : null,
+    }))
+  );
 
   return new ImageResponse(
     (
@@ -118,24 +140,23 @@ export async function GET() {
             paddingRight: '20px',
           }}>
             {hasRealItems ? (
-              // Display real item covers
-              demoItems.map((item) => (
-                <div 
-                  key={item.id} 
-                  style={{ 
+              prepared.map((item) => (
+                <div
+                  key={item.id}
+                  style={{
                     display: 'flex',
                     width: '120px',
                     height: '170px',
                     borderRadius: '4px',
                     overflow: 'hidden',
                     boxShadow: '0 4px 12px rgba(0,0,0,0.2), 0 2px 4px rgba(0,0,0,0.1)',
-                    background: item.image_url ? 'transparent' : getTypeGradient(item.type),
+                    background: item.image_data ? 'transparent' : getTypeGradient(item.type),
                   }}
                 >
-                  {item.image_url ? (
+                  {item.image_data ? (
                     // eslint-disable-next-line @next/next/no-img-element
                     <img
-                      src={item.image_url}
+                      src={item.image_data}
                       alt={item.title}
                       style={{
                         width: '100%',
@@ -206,7 +227,11 @@ export async function GET() {
         </div>
       </div>
     ),
-    { width: 1200, height: 630 }
+    {
+      width: 1200,
+      height: 630,
+      headers: { 'Cache-Control': OG_CACHE_CONTROL, ETag: etag },
+    }
   );
 }
 

--- a/lib/og/imageLoader.ts
+++ b/lib/og/imageLoader.ts
@@ -1,0 +1,39 @@
+export const IMAGE_FETCH_TIMEOUT_MS = 2500;
+export const OG_CACHE_CONTROL = 'public, max-age=300, s-maxage=3600, stale-while-revalidate=86400';
+
+/**
+ * Fetch an external image and return it as a base64 data URL.
+ *
+ * Used by edge OG routes to prefetch covers before handing them to Satori.
+ * Satori has no built-in timeout and will abort the whole render if a single
+ * image hangs — fetching here lets a slow/broken cover fail in isolation so
+ * the route can fall back to a placeholder for that one tile.
+ */
+export async function fetchAsDataUrl(url: string): Promise<string | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), IMAGE_FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { Accept: 'image/*' },
+    });
+    if (!res.ok) return null;
+    const contentType = res.headers.get('content-type') || 'image/jpeg';
+    if (!contentType.startsWith('image/')) return null;
+    const buffer = await res.arrayBuffer();
+    return `data:${contentType};base64,${uint8ToBase64(new Uint8Array(buffer))}`;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function uint8ToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode.apply(null, Array.from(bytes.subarray(i, i + chunk)));
+  }
+  return btoa(binary);
+}


### PR DESCRIPTION
## Summary
- **Reliability:** prefetch cover images server-side with a 2.5s per-image timeout (parallel) and inline as data URLs. A failed/slow cover now falls back to a typed gradient tile instead of silently breaking the whole OG image at Satori render time. Applied to both shelf and landing routes.
- **Caching:** weak ETag + `If-None-Match` → 304 short-circuit on both routes. Shelf ETag derived from `max(shelf.updated_at, items[].updated_at)`; landing ETag from max demo item updated_at. Adds `Cache-Control: public, max-age=300, s-maxage=3600, stale-while-revalidate=86400`.
- **Visuals (shelf only):** square covers for music/podcast/video, portrait for books; type icon on fallback tiles; redesigned "+N more" as a stacked card; cleaner shelf-name truncation.
- **Refactor:** shared `fetchAsDataUrl` + `OG_CACHE_CONTROL` extracted to `lib/og/imageLoader.ts`.

## Test plan
- [x] `npm run lint` — no new warnings
- [x] `npm run build` — passes
- [x] Shelf route: manual render, headers, 304 round-trip
- [x] Landing route: manual render, headers, 304 round-trip
- [x] Fallback path (invalid token) renders cleanly
- [ ] Validate on Twitter / LinkedIn debug previewer after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)