### PR TITLE
Security headers + IP rate limiting on external-API routes

### DIFF
--- a/lib/utils/rateLimit.ts
+++ b/lib/utils/rateLimit.ts
@@ -28,6 +28,7 @@ function getRedis(): Redis {
 let _loginRateLimiter: Ratelimit | null = null;
 let _signupRateLimiter: Ratelimit | null = null;
 let _oauthRateLimiter: Ratelimit | null = null;
+let _externalApiRateLimiter: Ratelimit | null = null;
 
 /**
  * Rate limiter for login endpoint: 5 requests per minute
@@ -75,6 +76,23 @@ export function getOAuthRateLimiter(): Ratelimit {
     });
   }
   return _oauthRateLimiter;
+}
+
+/**
+ * Rate limiter for routes that fan out to paid/quota'd external APIs
+ * (Spotify, Google Books, YouTube, Yahoo Finance, Microlink): 30 requests
+ * per minute per IP. Protects upstream quotas from anonymous abuse.
+ */
+export function getExternalApiRateLimiter(): Ratelimit {
+  if (!_externalApiRateLimiter) {
+    _externalApiRateLimiter = new Ratelimit({
+      redis: getRedis(),
+      limiter: Ratelimit.slidingWindow(30, '1 m'),
+      analytics: true,
+      prefix: 'ratelimit:external_api',
+    });
+  }
+  return _externalApiRateLimiter;
 }
 
 /**
@@ -157,4 +175,5 @@ export function _resetRateLimitCache(): void {
   _loginRateLimiter = null;
   _signupRateLimiter = null;
   _oauthRateLimiter = null;
+  _externalApiRateLimiter = null;
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getExternalApiRateLimiter,
+  checkRateLimit,
+  isRateLimitingEnabled,
+  getClientIP,
+} from '@/lib/utils/rateLimit';
+import { createLogger } from '@/lib/utils/logger';
+
+const logger = createLogger('Middleware');
+
+// Routes that fan out to paid/quota'd external APIs and need IP rate limiting.
+// Order matters: prefix matches are checked top-down.
+const EXTERNAL_API_PREFIXES = [
+  '/api/search/',
+  '/api/finance/',
+  '/api/import/',
+  '/api/items/from-url',
+];
+
+function needsExternalApiRateLimit(pathname: string): boolean {
+  return EXTERNAL_API_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (!needsExternalApiRateLimit(pathname)) {
+    return NextResponse.next();
+  }
+
+  // Gracefully no-op when Upstash isn't configured (e.g. local dev without env).
+  if (!isRateLimitingEnabled()) {
+    return NextResponse.next();
+  }
+
+  try {
+    const ip = getClientIP(request);
+    const result = await checkRateLimit(getExternalApiRateLimiter(), `ip:${ip}`);
+    if (!result.success && result.response) {
+      return result.response;
+    }
+  } catch (error) {
+    // If the limiter itself fails (Redis hiccup), fail open rather than 500-ing the user.
+    logger.errorWithException('Rate limit check failed; allowing request', error);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    '/api/search/:path*',
+    '/api/finance/:path*',
+    '/api/import/:path*',
+    '/api/items/from-url',
+  ],
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,15 @@
 import type { NextConfig } from "next";
 
+// Security headers applied to all routes except /embed/* (which needs to be iframed cross-origin).
+const baseSecurityHeaders = [
+  { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=(), interest-cohort=()' },
+  { key: 'X-DNS-Prefetch-Control', value: 'on' },
+];
+
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
@@ -12,9 +22,17 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        // Negative lookahead: applies to every path except those starting with embed/
+        source: '/((?!embed/).*)',
+        headers: baseSecurityHeaders,
+      },
+      {
         source: '/embed/:path*',
         headers: [
           { key: 'Content-Security-Policy', value: 'frame-ancestors *' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=(), interest-cohort=()' },
         ],
       },
     ];


### PR DESCRIPTION
## Summary

- Adds baseline security headers (HSTS, X-Content-Type-Options, Referrer-Policy, X-Frame-Options, Permissions-Policy, X-DNS-Prefetch-Control) site-wide. Preserves the existing cross-origin iframe allowance for `/embed/*` (uses CSP `frame-ancestors *` plus a narrower header set so the embed flow keeps working).
- Adds a Next.js `middleware.ts` that rate-limits routes hitting paid/quota'd external APIs at **30 req/min per IP** via the existing Upstash Redis limiter. Targets `/api/search/*`, `/api/finance/*`, `/api/import/*`, and `/api/items/from-url`.
- Extends `lib/utils/rateLimit.ts` with `getExternalApiRateLimiter()` (sliding window, prefix `ratelimit:external_api`).

## Why

Audit of `app/api/**/route.ts` found that only `/api/auth/{login,signup,google}` had rate limiting. The highest-risk gap was anonymous routes (`/api/search/*`, `/api/finance/*`) that proxy to Spotify, Google Books, YouTube, and Yahoo Finance — abuse there burns paid quota with zero friction. Microlink (used by `/api/items/from-url` and `/api/import/*`) has documented quota failures too. Closing those first is the highest-leverage move.

## Scope notes

- **Not yet covered:** authenticated mutating endpoints (CRUD on shelves/items). They already require a valid session, so the abuse vector is much narrower. Adding per-user limits there is a clean follow-up.
- **No enforced CSP** beyond the existing `/embed/*` `frame-ancestors *`. A site-wide CSP needs careful testing across Google OAuth, Vercel Analytics, and inline hydration scripts; report-only mode is the natural next step.
- Middleware **fails open** if the limiter throws (Redis hiccup) and **no-ops** when Upstash env vars aren't configured (local dev).

## Test plan

- [x] `npm run lint` — no new warnings
- [x] `npm run test:run` — 623 tests / 35 files pass
- [x] `npx tsc --noEmit` — zero type errors in touched files (pre-existing errors in unrelated test files only)
- [ ] Manually verify in deployed preview: response headers show new security headers on `/`, `/dashboard`, `/s/[token]`; `/embed/[token]` still iframes from a third-party origin
- [ ] Manually verify: hammering `/api/search/books?q=foo` from one IP returns 429 after 30 hits within a minute, with `Retry-After` header set

🤖 Generated with [Claude Code](https://claude.com/claude-code)