### PR TITLE
test: fix flaky episode-browser test

### DIFF
--- a/components/shelf/AddItemFormEpisodes.test.tsx
+++ b/components/shelf/AddItemFormEpisodes.test.tsx
@@ -116,15 +116,16 @@ describe('AddItemForm - Episode Browsing', () => {
     // Click Browse Episodes
     fireEvent.click(screen.getByText('Browse Episodes →'));
 
-    await waitFor(() => {
-      // Use a more flexible text matching approach
-      const heading = screen.getByRole('heading', { level: 3 });
-      expect(heading.textContent).toContain('Episodes from');
-      expect(heading.textContent).toContain('Test Podcast Show');
-    });
+    // findByText retries until the async-rendered episode list is in the DOM,
+    // so the assertions below no longer race the render cycle that follows the
+    // heading (the source of CI flakiness).
+    expect(await screen.findByText(/Episode 1: Introduction/i)).toBeInTheDocument();
+
+    const heading = screen.getByRole('heading', { level: 3 });
+    expect(heading.textContent).toContain('Episodes from');
+    expect(heading.textContent).toContain('Test Podcast Show');
 
     // Check that episodes are displayed
-    expect(screen.getByText(/Episode 1: Introduction/i)).toBeInTheDocument();
     expect(screen.getByText(/Episode 2: Deep Dive/i)).toBeInTheDocument();
 
     // Check that episodes have duration info (don't need exact matching)


### PR DESCRIPTION
## What

Fixes the flaky `components/shelf/AddItemFormEpisodes.test.tsx › displays episodes when Browse Episodes is clicked` test. Closes #154.

## Root cause

After clicking **Browse Episodes →**, the test wrapped only the *heading* assertion in `waitFor`, then checked the episode list with synchronous `getByText(/Episode 1: Introduction/i)`. The list renders a render-cycle after the heading, so on the slower CI runner `getByText` ran before the list mounted and threw:

```
TestingLibraryElementError: Unable to find an element with the text: /Episode 1: Introduction/i
```

It passed locally every time (incl. full `test:ci`), failed intermittently in CI — surfaced on #152's post-merge CI.

## Fix

Use async `findByText` (retries to the timeout) for the first episode, so the test waits for the async-rendered list before asserting the heading and remaining rows. Test-only change; no production code touched.

## Verification
- Ran the file repeatedly locally — 4/4 pass each time.
- Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)