### PR TITLE
fix: Google Books API key + yahoo-finance2 validation hardening

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "virtual-bookshelf",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/app/api/finance/quote/route.ts
+++ b/app/api/finance/quote/route.ts
@@ -52,10 +52,14 @@ export async function GET(request: Request) {
   try {
     // Fetch quote and company profile in parallel
     const [quote, summary] = await Promise.all([
-      yahooFinance.quote(symbol, {
-        fields: ['regularMarketPrice', 'regularMarketChange', 'regularMarketChangePercent',
-                 'fiftyTwoWeekLow', 'fiftyTwoWeekHigh', 'shortName', 'longName', 'currency'],
-      }) as Promise<{
+      yahooFinance.quote(
+        symbol,
+        {
+          fields: ['regularMarketPrice', 'regularMarketChange', 'regularMarketChangePercent',
+                   'fiftyTwoWeekLow', 'fiftyTwoWeekHigh', 'shortName', 'longName', 'currency'],
+        },
+        { validateResult: false }
+      ) as Promise<{
         longName?: string;
         shortName?: string;
         regularMarketPrice?: number;
@@ -64,7 +68,7 @@ export async function GET(request: Request) {
         fiftyTwoWeekLow?: number;
         fiftyTwoWeekHigh?: number;
         currency?: string;
-      }>,
+      } | undefined>,
       yahooFinance.quoteSummary(
         symbol,
         { modules: ['assetProfile'] },
@@ -74,6 +78,10 @@ export async function GET(request: Request) {
         return null;
       }),
     ]);
+
+    if (!quote) {
+      return NextResponse.json({ success: false, error: `No data found for ticker "${symbol}"` }, { status: 404 });
+    }
 
     // Primary: Financial Modeling Prep has high-quality ticker-based logos, no API key needed
     const fmpLogoUrl = `https://financialmodelingprep.com/image-stock/${symbol}.png`;

--- a/app/api/finance/quote/route.ts
+++ b/app/api/finance/quote/route.ts
@@ -79,7 +79,7 @@ export async function GET(request: Request) {
       }),
     ]);
 
-    if (!quote) {
+    if (!quote || quote.regularMarketPrice == null) {
       return NextResponse.json({ success: false, error: `No data found for ticker "${symbol}"` }, { status: 404 });
     }
 

--- a/components/shelf/StockDrawer.tsx
+++ b/components/shelf/StockDrawer.tsx
@@ -153,16 +153,20 @@ export function StockDrawer({ item }: StockDrawerProps) {
           <div className="flex flex-wrap gap-x-6 gap-y-2 items-baseline">
             <div>
               <span className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-                {quote.price.toFixed(2)}
+                {quote.price?.toFixed(2) ?? '—'}
               </span>
               <span className="text-sm text-gray-500 dark:text-gray-400 ml-1">{quote.currency}</span>
             </div>
-            <div className={`text-sm font-medium ${isPositive ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-              {isPositive ? '+' : ''}{quote.change.toFixed(2)} ({isPositive ? '+' : ''}{quote.changePercent.toFixed(2)}%)
-            </div>
-            <div className="text-xs text-gray-500 dark:text-gray-400">
-              52W: {quote.fiftyTwoWeekLow.toFixed(2)} – {quote.fiftyTwoWeekHigh.toFixed(2)}
-            </div>
+            {quote.change != null && quote.changePercent != null && (
+              <div className={`text-sm font-medium ${isPositive ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                {isPositive ? '+' : ''}{quote.change.toFixed(2)} ({isPositive ? '+' : ''}{quote.changePercent.toFixed(2)}%)
+              </div>
+            )}
+            {quote.fiftyTwoWeekLow != null && quote.fiftyTwoWeekHigh != null && (
+              <div className="text-xs text-gray-500 dark:text-gray-400">
+                52W: {quote.fiftyTwoWeekLow.toFixed(2)} – {quote.fiftyTwoWeekHigh.toFixed(2)}
+              </div>
+            )}
           </div>
         ) : (
           <div className="h-8 w-48 bg-gray-200 dark:bg-gray-700 animate-pulse rounded" />

--- a/components/shelf/forms/StockTickerForm.tsx
+++ b/components/shelf/forms/StockTickerForm.tsx
@@ -104,7 +104,7 @@ export function StockTickerForm({ onAdd, adding }: StockTickerFormProps) {
             <div>
               <p className="font-medium text-gray-900 dark:text-gray-100">{preview.name}</p>
               <p className="text-sm text-gray-500 dark:text-gray-400">
-                {ticker.trim().toUpperCase()} · {preview.price.toFixed(2)} {preview.currency}
+                {ticker.trim().toUpperCase()}{preview.price != null ? ` · ${preview.price.toFixed(2)} ${preview.currency}` : ''}
               </p>
             </div>
           </div>

--- a/lib/api/googleBooks.ts
+++ b/lib/api/googleBooks.ts
@@ -1,18 +1,15 @@
-// Google Books API integration for book search
+// Open Library API integration for book search (replaces Google Books which hit quota limits)
 
-interface GoogleBooksVolumeInfo {
+interface OpenLibraryDoc {
+  key: string;
   title: string;
-  authors?: string[];
-  imageLinks?: {
-    thumbnail?: string;
-    smallThumbnail?: string;
-  };
-  infoLink?: string;
+  author_name?: string[];
+  cover_i?: number;
 }
 
-interface GoogleBooksItem {
-  id: string;
-  volumeInfo: GoogleBooksVolumeInfo;
+interface OpenLibraryResponse {
+  docs: OpenLibraryDoc[];
+  numFound: number;
 }
 
 export interface BookItem {
@@ -24,35 +21,29 @@ export interface BookItem {
   type: 'book';
 }
 
-/**
- * Search for books using Google Books API
- * No API key required for basic searches
- */
 export async function searchBooks(query: string): Promise<BookItem[]> {
   const response = await fetch(
-    `https://www.googleapis.com/books/v1/volumes?q=${encodeURIComponent(query)}&maxResults=10`,
+    `https://openlibrary.org/search.json?q=${encodeURIComponent(query)}&limit=10&fields=key,title,author_name,cover_i`,
     {
-      headers: {
-        'Accept': 'application/json',
-      },
+      headers: { 'Accept': 'application/json' },
     }
   );
 
   if (!response.ok) {
-    throw new Error('Failed to search Google Books');
+    throw new Error('Failed to search Open Library');
   }
 
-  const data = await response.json();
-  const items: GoogleBooksItem[] = data.items || [];
+  const data: OpenLibraryResponse = await response.json();
+  const docs = data.docs ?? [];
 
-  return items.map((item) => ({
-    id: item.id,
-    title: item.volumeInfo.title,
-    creator: item.volumeInfo.authors?.join(', ') || 'Unknown Author',
-    imageUrl: item.volumeInfo.imageLinks?.thumbnail?.replace('http://', 'https://') || 
-              item.volumeInfo.imageLinks?.smallThumbnail?.replace('http://', 'https://') || 
-              '',
-    externalUrl: item.volumeInfo.infoLink || `https://books.google.com/books?id=${item.id}`,
+  return docs.map((doc) => ({
+    id: doc.key,
+    title: doc.title,
+    creator: doc.author_name?.join(', ') || 'Unknown Author',
+    imageUrl: doc.cover_i
+      ? `https://covers.openlibrary.org/b/id/${doc.cover_i}-M.jpg`
+      : '',
+    externalUrl: `https://openlibrary.org${doc.key}`,
     type: 'book' as const,
   }));
 }

--- a/lib/api/googleBooks.ts
+++ b/lib/api/googleBooks.ts
@@ -1,15 +1,18 @@
-// Open Library API integration for book search (replaces Google Books which hit quota limits)
+// Google Books API integration for book search
 
-interface OpenLibraryDoc {
-  key: string;
+interface GoogleBooksVolumeInfo {
   title: string;
-  author_name?: string[];
-  cover_i?: number;
+  authors?: string[];
+  imageLinks?: {
+    thumbnail?: string;
+    smallThumbnail?: string;
+  };
+  infoLink?: string;
 }
 
-interface OpenLibraryResponse {
-  docs: OpenLibraryDoc[];
-  numFound: number;
+interface GoogleBooksItem {
+  id: string;
+  volumeInfo: GoogleBooksVolumeInfo;
 }
 
 export interface BookItem {
@@ -22,28 +25,31 @@ export interface BookItem {
 }
 
 export async function searchBooks(query: string): Promise<BookItem[]> {
-  const response = await fetch(
-    `https://openlibrary.org/search.json?q=${encodeURIComponent(query)}&limit=10&fields=key,title,author_name,cover_i`,
-    {
-      headers: { 'Accept': 'application/json' },
-    }
-  );
+  const apiKey = process.env.GOOGLE_BOOKS_API_KEY;
+  const url = new URL('https://www.googleapis.com/books/v1/volumes');
+  url.searchParams.set('q', query);
+  url.searchParams.set('maxResults', '10');
+  if (apiKey) url.searchParams.set('key', apiKey);
+
+  const response = await fetch(url.toString(), {
+    headers: { 'Accept': 'application/json' },
+  });
 
   if (!response.ok) {
-    throw new Error('Failed to search Open Library');
+    throw new Error('Failed to search Google Books');
   }
 
-  const data: OpenLibraryResponse = await response.json();
-  const docs = data.docs ?? [];
+  const data = await response.json();
+  const items: GoogleBooksItem[] = data.items || [];
 
-  return docs.map((doc) => ({
-    id: doc.key,
-    title: doc.title,
-    creator: doc.author_name?.join(', ') || 'Unknown Author',
-    imageUrl: doc.cover_i
-      ? `https://covers.openlibrary.org/b/id/${doc.cover_i}-M.jpg`
-      : '',
-    externalUrl: `https://openlibrary.org${doc.key}`,
+  return items.map((item) => ({
+    id: item.id,
+    title: item.volumeInfo.title,
+    creator: item.volumeInfo.authors?.join(', ') || 'Unknown Author',
+    imageUrl: item.volumeInfo.imageLinks?.thumbnail?.replace('http://', 'https://') ||
+              item.volumeInfo.imageLinks?.smallThumbnail?.replace('http://', 'https://') ||
+              '',
+    externalUrl: item.volumeInfo.infoLink || `https://books.google.com/books?id=${item.id}`,
     type: 'book' as const,
   }));
 }


### PR DESCRIPTION
## Summary
- **Google Books returning no results**: Google disabled anonymous (keyless) access to the Books API — quota is now set to 0 for the shared anonymous project. Fixed by reading `GOOGLE_BOOKS_API_KEY` from env and passing it with each request. Key has been added to Vercel.
- **Stock lookup error**: `yahoo-finance2` v3 throws schema validation errors when Yahoo Finance's response format drifts. Added `validateResult: false` to `quote()` and a null guard for unknown tickers (previously caused a TypeError crash before reaching the error handler).

## Test plan
- [ ] Search for a book — results should appear
- [ ] Look up a stock ticker (e.g. AAPL, NVDA) — preview card should appear
- [ ] Look up an invalid ticker — should show "Could not find ticker" instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)