### PR TITLE
chore: clear eslint no-unused-vars warnings

### DIFF
--- a/app/shelf/[shelfId]/edit/page.tsx
+++ b/app/shelf/[shelfId]/edit/page.tsx
@@ -151,21 +151,6 @@ export default function EditShelfPage() {
         }
     };
 
-    const handleReorder = async (itemIds: string[]) => {
-        try {
-            const res = await fetch(`/api/shelf/${shelfId}/reorder`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ item_ids: itemIds }),
-            });
-            if (res.ok) {
-                fetchShelf();
-            }
-        } catch (err) {
-            console.error('Reorder error:', err);
-        }
-    };
-
     const handleSaveNote = async (notes: string | null, rating: number | null) => {
         if (!noteEditItem) return;
         

--- a/components/ui/StarInput.tsx
+++ b/components/ui/StarInput.tsx
@@ -41,8 +41,7 @@ export function StarInput({ value, onChange, size = 'md', label = 'Rating' }: St
 
   for (let i = 1; i <= 5; i++) {
     const isFilled = i <= displayRating;
-    const isHovered = hoverRating !== null && i <= hoverRating;
-    
+
     stars.push(
       <button
         key={i}

--- a/test/utils/mocks.ts
+++ b/test/utils/mocks.ts
@@ -5,7 +5,7 @@
  * that are commonly used across multiple test files.
  */
 
-import { Item, Shelf, User, ItemType } from '@/lib/types/shelf';
+import { Item, Shelf, User } from '@/lib/types/shelf';
 
 /**
  * Creates a mock Item with default values that can be overridden


### PR DESCRIPTION
## What

Removes three unused symbols flagged by `@typescript-eslint/no-unused-vars`, so `npm run lint` is warning-free (previously 0 errors / 3 warnings, now 0 / 0).

| File | Removed | Why it was safe |
|------|---------|-----------------|
| `app/shelf/[shelfId]/edit/page.tsx` | `handleReorder` function | Orphaned — never passed to `ShelfGrid` (which has no `onReorder` prop) and pointed at a stale `/api/shelf/[shelfId]/reorder` endpoint. The live reorder path is fully handled inside `ShelfContainerDnd`, which POSTs to `/api/items/reorder`. |
| `components/ui/StarInput.tsx` | `isHovered` const | Dead value. Hover visuals already derive from `displayRating` + CSS `hover:` classes, so rendered output is unchanged. |
| `test/utils/mocks.ts` | `ItemType` import | Imported but never referenced. |

## Why

Keep the lint run clean so real issues aren't buried under standing warnings. All three are pure dead-code removals with no runtime behavior change.

## Notes for reviewer

- No browser verification needed — nothing observable changed. `npm run lint` now passes with zero warnings.
- **Follow-up (not in this PR):** with `handleReorder` gone, the route handler at `app/api/shelf/[shelfId]/reorder/route.ts` now has zero callers anywhere in the app and is dead code. Deleting a whole API route felt like a heavier, separate decision than a lint cleanup, so it's intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)