### PR TITLE
Landing: full capability showcase + seeded sample shelves

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -84,7 +84,7 @@ export default async function Home() {
 
         {/* Live demo gallery — real, click-through example shelves */}
         {hasDemo && demoShelves && (
-          <section className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 pb-20 sm:pb-28">
+          <section className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 pb-4">
             <p className="text-center text-sm font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-5">
               Real shelves · tap to explore
             </p>
@@ -101,7 +101,7 @@ export default async function Home() {
         )}
 
         {/* Capability showcase */}
-        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-4">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
           <CapabilityShowcase />
 
           {/* How it works */}

--- a/components/home/CapabilityShowcase.test.tsx
+++ b/components/home/CapabilityShowcase.test.tsx
@@ -5,11 +5,6 @@ import { CAPABILITY_TILES } from '@/lib/constants/landingShowcase';
 
 describe('CapabilityShowcase', () => {
   describe('Rendering', () => {
-    it('renders the section heading', () => {
-      render(<CapabilityShowcase />);
-      expect(screen.getByRole('heading', { name: 'Shelve anything' })).toBeInTheDocument();
-    });
-
     it('renders a labeled icon for every media type', () => {
       render(<CapabilityShowcase />);
       for (const tile of CAPABILITY_TILES) {

--- a/components/home/CapabilityShowcase.tsx
+++ b/components/home/CapabilityShowcase.tsx
@@ -80,16 +80,7 @@ function Icon({ type, className = 'w-7 h-7' }: { type: ItemType; className?: str
 
 export function CapabilityShowcase() {
   return (
-    <section aria-labelledby="capabilities-heading" className="mb-20 sm:mb-28">
-      <div className="text-center mb-10">
-        <h2 id="capabilities-heading" className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 tracking-tight">
-          Shelve anything
-        </h2>
-        <p className="mt-3 text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
-          One shelf holds it all — covers, artwork, and details pull in automatically.
-        </p>
-      </div>
-
+    <section aria-label="Supported item types" className="mb-20 sm:mb-28">
       <ul className="flex flex-wrap items-start justify-center gap-x-6 gap-y-7 sm:gap-x-10">
         {CAPABILITY_TILES.map((tile) => (
           <li

--- a/components/home/CapabilityShowcase.tsx
+++ b/components/home/CapabilityShowcase.tsx
@@ -80,7 +80,7 @@ function Icon({ type, className = 'w-7 h-7' }: { type: ItemType; className?: str
 
 export function CapabilityShowcase() {
   return (
-    <section aria-label="Supported item types" className="mb-20 sm:mb-28">
+    <section aria-label="Supported item types" className="mb-12 sm:mb-16">
       <ul className="flex flex-wrap items-start justify-center gap-x-6 gap-y-7 sm:gap-x-10">
         {CAPABILITY_TILES.map((tile) => (
           <li

--- a/components/home/DemoShelf.test.tsx
+++ b/components/home/DemoShelf.test.tsx
@@ -108,7 +108,7 @@ describe('DemoShelf', () => {
     expect(links[0]).toHaveAttribute('href', '/s/abc123');
   });
 
-  it('limits display to 12 items', () => {
+  it('limits display to 8 items', () => {
     const manyItems: Item[] = Array.from({ length: 15 }, (_, i) => ({
       id: `item-${i}`,
       shelf_id: 'shelf-1',
@@ -130,9 +130,9 @@ describe('DemoShelf', () => {
       />
     );
 
-    // Should only render 12 images (limited to 12, created 15)
+    // Should only render 8 images (limited to 8, created 15)
     const images = screen.getAllByRole('img');
-    expect(images).toHaveLength(12);
+    expect(images).toHaveLength(8);
   });
 
   it('renders explore prompt', () => {

--- a/components/home/DemoShelf.tsx
+++ b/components/home/DemoShelf.tsx
@@ -24,8 +24,8 @@ function itemImageUrl(item: Item): string | null {
  * Clickable to view the full demo shelf
  */
 export function DemoShelf({ items, shelfName, shareToken }: DemoShelfProps) {
-  // Show up to 12 items to fill two rows on desktop
-  const displayItems = items.slice(0, 12);
+  // Preview a single row; the full shelf lives behind "Click to explore".
+  const displayItems = items.slice(0, 8);
   const shelfUrl = `/s/${shareToken}`;
 
   return (
@@ -43,10 +43,11 @@ export function DemoShelf({ items, shelfName, shareToken }: DemoShelfProps) {
           </span>
         </div>
 
-        {/* Shelf items */}
-        <div className="bg-white/50 dark:bg-gray-900/50 backdrop-blur-sm">
+        {/* Shelf items — a single row that clips (never wraps), so a full
+            shelf can't spill onto a second visual line under one ledge. */}
+        <div className="relative bg-white/50 dark:bg-gray-900/50 backdrop-blur-sm">
           <div
-            className="px-4 py-4 flex flex-wrap gap-3"
+            className="px-4 py-4 flex gap-3 overflow-hidden"
             style={{ alignItems: 'flex-end' }}
           >
             {displayItems.map((item) => (
@@ -75,6 +76,8 @@ export function DemoShelf({ items, shelfName, shareToken }: DemoShelfProps) {
               </div>
             ))}
           </div>
+          {/* Soft right-edge fade hints more items live on the full shelf. */}
+          <div className="pointer-events-none absolute right-0 top-0 bottom-1.5 w-12 bg-gradient-to-l from-white dark:from-gray-900 to-transparent" />
 
           {/* Shelf divider */}
           <div

--- a/components/home/RotatingDemoShelf.tsx
+++ b/components/home/RotatingDemoShelf.tsx
@@ -296,7 +296,7 @@ export function RotatingDemoShelf({
       </div>
 
       {/* Navigation dots and helper text */}
-      <div className="mt-4 flex flex-col items-center gap-3">
+      <div className="mt-3 flex flex-col items-center gap-2">
         {/* Dots - only show if multiple shelves */}
         {shelfCount > 1 && (
           <div className="flex gap-2" role="tablist" aria-label="Shelf navigation">

--- a/components/home/RotatingDemoShelf.tsx
+++ b/components/home/RotatingDemoShelf.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Item, Shelf } from '@/lib/types/shelf';
+import { splitIntoRows } from '@/lib/utils/shelfLayout';
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -39,6 +40,7 @@ export function RotatingDemoShelf({
   const [slideDirection, setSlideDirection] = useState<'left' | 'right'>('left');
   const touchStartX = useRef<number | null>(null);
   const touchEndX = useRef<number | null>(null);
+  const ITEMS_PER_ROW = 6;
 
   const shelfCount = shelves.length;
 
@@ -127,7 +129,12 @@ export function RotatingDemoShelf({
   if (shelfCount === 0) return null;
 
   const currentShelf = shelves[activeIndex];
-  const displayItems = currentShelf.items.slice(0, 12);
+  // Preview up to MAX_PREVIEW_ROWS ledges; the full shelf lives behind
+  // "Click to explore". Items overflow onto a second ledge rather than wrapping
+  // awkwardly under one.
+  const MAX_PREVIEW_ROWS = 2;
+  const previewItems = currentShelf.items.slice(0, ITEMS_PER_ROW * MAX_PREVIEW_ROWS);
+  const rows = splitIntoRows(previewItems, ITEMS_PER_ROW);
   const shelfUrl = `/s/${currentShelf.shelf.share_token}`;
 
   // Animation classes based on direction
@@ -204,49 +211,51 @@ export function RotatingDemoShelf({
               </span>
             </div>
 
-            {/* Shelf items */}
+            {/* Shelf items — split into rows that each rest on their own wooden
+                ledge, so a fuller shelf reads as a real multi-shelf bookshelf
+                instead of wrapping under a single ledge. */}
             <div className="bg-gradient-to-b from-white dark:from-gray-900 to-gray-50/50 dark:to-gray-800/50">
-              <div
-                className="px-4 py-4 flex flex-wrap gap-3"
-                style={{ alignItems: 'flex-end' }}
-              >
-                {displayItems.map((item, itemIndex) => (
-                  <div
-                    key={item.id}
-                    className="flex-shrink-0 w-[80px] sm:w-[100px] transform transition-transform duration-300 group-hover:scale-[1.02]"
-                    style={{ 
-                      transitionDelay: `${itemIndex * 30}ms`,
-                    }}
-                  >
-                    <div className={`relative aspect-[2/3] rounded overflow-hidden shadow-md group-hover:shadow-lg transition-shadow duration-300 ${item.type === 'stock' ? 'bg-white' : 'bg-gray-100 dark:bg-gray-800'}`}>
-                      {itemImageUrl(item) ? (
-                        <Image
-                          src={itemImageUrl(item)!}
-                          alt={item.title}
-                          fill
-                          sizes="100px"
-                          className={item.type === 'stock' ? 'object-contain p-2' : 'object-cover'}
-                          unoptimized
-                        />
-                      ) : (
-                        <div className="absolute inset-0 flex items-center justify-center p-2 bg-gradient-to-br from-gray-100 dark:from-gray-800 to-gray-200 dark:to-gray-700">
-                          <span className="text-xs text-gray-500 dark:text-gray-400 text-center line-clamp-3 font-medium">
-                            {item.title}
-                          </span>
+              {rows.map((row, rowIndex) => (
+                <div key={rowIndex}>
+                  <div className="px-4 pt-4 flex gap-3" style={{ alignItems: 'flex-end' }}>
+                    {row.map((item, itemIndex) => (
+                      <div
+                        key={item.id}
+                        className="flex-shrink-0 w-[80px] sm:w-[100px] transform transition-transform duration-300 group-hover:scale-[1.02]"
+                        style={{ transitionDelay: `${itemIndex * 30}ms` }}
+                      >
+                        <div className={`relative aspect-[2/3] rounded overflow-hidden shadow-md group-hover:shadow-lg transition-shadow duration-300 ${item.type === 'stock' ? 'bg-white' : 'bg-gray-100 dark:bg-gray-800'}`}>
+                          {itemImageUrl(item) ? (
+                            <Image
+                              src={itemImageUrl(item)!}
+                              alt={item.title}
+                              fill
+                              sizes="100px"
+                              className={item.type === 'stock' ? 'object-contain p-2' : 'object-cover'}
+                              unoptimized
+                            />
+                          ) : (
+                            <div className="absolute inset-0 flex items-center justify-center p-2 bg-gradient-to-br from-gray-100 dark:from-gray-800 to-gray-200 dark:to-gray-700">
+                              <span className="text-xs text-gray-500 dark:text-gray-400 text-center line-clamp-3 font-medium">
+                                {item.title}
+                              </span>
+                            </div>
+                          )}
                         </div>
-                      )}
-                    </div>
+                      </div>
+                    ))}
                   </div>
-                ))}
-              </div>
 
-              {/* Shelf divider - wooden shelf look */}
-              <div
-                className="h-2 bg-gradient-to-r from-amber-700 via-amber-600 to-amber-700"
-                style={{
-                  boxShadow: '0 4px 12px rgba(0, 0, 0, 0.3), 0 2px 4px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.1)',
-                }}
-              />
+                  {/* Wooden ledge under this row */}
+                  <div
+                    className="h-2 bg-gradient-to-r from-amber-700 via-amber-600 to-amber-700"
+                    style={{
+                      boxShadow:
+                        '0 4px 12px rgba(0, 0, 0, 0.3), 0 2px 4px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.1)',
+                    }}
+                  />
+                </div>
+              ))}
             </div>
           </Link>
         </div>


### PR DESCRIPTION
## What & why

The home page was built when shelves held only books, podcasts, and music — and its copy said exactly that. Shelves now hold **7 item types** (books, podcasts, episodes, music, videos, links, and live **stock tickers** with a real-time quote / 1-year chart / news drawer), plus notes, ratings, sharing, and embeds. This rebuilds the landing page into a capability showcase, seeds real click-through sample shelves, and makes the demo carousel use real shelf embeds.

## Changes

**Landing (`app/page.tsx`)**
- Hero → live rotating demo carousel → a compact "Shelve anything" icon row (one per media type, Stocks flagged **Live**) → "Search · Click · Added" 3-step → CTA.
- Static showcase renders even with no demo data; the carousel degrades gracefully when `DEMO_USER_ID` is unset.

**Demo carousel = real embeds (`components/home/RotatingShelfEmbeds`)**
- Rotates iframes of the real `/embed/[shareToken]` view instead of a bespoke preview, so the landing dogfoods the embed and there's a single shelf renderer (no separate preview to drift / "double up").
- Each slide auto-sizes to the height the embed broadcasts via `postMessage`.
- Removes the old `RotatingDemoShelf` / `DemoShelf` components.

**Embed height fix (`app/embed/[shareToken]/EmbedShelf.tsx`)**
- Measure the content wrapper, not `document.documentElement` — the latter stretches to the host-set iframe height and fed its own value back, so any host auto-sizing the iframe got a stuck ~1845px. Each shelf now reports its true content height.

**Seed (`scripts/seed-landing-shelves.ts`, `npm run seed`)**
- Idempotent. Creates/refreshes an admin account and 5 public sample shelves spanning all 7 types (29 items). Every cover URL was HEAD-checked. Prints the admin user id for `DEMO_USER_ID`.

**Docs**: `docs/prds/LANDING_SHOWCASE_PRD.md` + `docs/guides/ADMIN_DEMO_SETUP.md` seed instructions.

## Verification
- `npm run lint`, `npm run test:run` (647 passing), `npm run build` all green.
- Seeded a Neon database; verified the carousel rotates real embeds, each auto-sized to its content (heights 273–621px, no feedback loop), stock logos render, light/dark/mobile clean, no console errors.

## Reviewer notes
- Requires `DEMO_USER_ID` set in the deploy env (and the finance API key for the live stock drawer).
- Migration `002_schema_hardening.sql` is intentionally **not** applied by the seed (the seed doesn't depend on it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)