### PR TITLE
fix: return 200 from /api/auth/me for unauthenticated requests

### DIFF
--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -9,14 +9,11 @@ export async function GET() {
     const session = await getSession();
     
     if (!session) {
-      return NextResponse.json(
-        { success: false, error: 'Not authenticated' },
-        { status: 401 }
-      );
+      return NextResponse.json({ authenticated: false });
     }
 
     return NextResponse.json({
-      success: true,
+      authenticated: true,
       data: {
         userId: session.userId,
         username: session.username,

--- a/app/shelf/[shelfId]/edit/page.tsx
+++ b/app/shelf/[shelfId]/edit/page.tsx
@@ -47,11 +47,8 @@ export default function EditShelfPage() {
         try {
             // Check auth first
             const authRes = await fetch('/api/auth/me');
-            if (!authRes.ok) {
-                router.push('/login');
-                return;
-            }
             const authJson = await authRes.json();
+            if (!authJson.authenticated) { router.push('/login'); return; }
             const userId = authJson.data.userId;
 
             // Fetch shelf data

--- a/app/shelf/[shelfId]/page.tsx
+++ b/app/shelf/[shelfId]/page.tsx
@@ -47,8 +47,8 @@ export default function ShelfPage() {
 
         try {
           const authRes = await fetch('/api/auth/me');
-          if (authRes.ok) {
-            const authJson = await authRes.json();
+          const authJson = await authRes.json();
+          if (authJson.authenticated) {
             setIsOwner(String(authJson.data.userId) === String(shelfJson.data.user_id));
           }
         } catch {

--- a/components/Navigation.test.tsx
+++ b/components/Navigation.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { Navigation } from './Navigation';
 
 // Mock next/navigation
@@ -13,7 +13,8 @@ describe('Navigation', () => {
     global.fetch = vi.fn(() =>
       Promise.resolve({
         ok: false,
-      } as Response)
+        json: () => Promise.resolve({ authenticated: false }),
+      } as unknown as Response)
     );
   });
 
@@ -69,35 +70,27 @@ describe('Navigation', () => {
       global.fetch = vi.fn(() =>
         Promise.resolve({
           ok: false,
-        } as Response)
+          json: () => Promise.resolve({ authenticated: false }),
+        } as unknown as Response)
       );
 
       render(<Navigation />);
-      
-      // Wait for auth check to complete
-      await new Promise(resolve => setTimeout(resolve, 100));
-      
-      const signInLink = screen.getByText('Sign In');
-      expect(signInLink).toBeInTheDocument();
+
+      expect(await screen.findByText('Sign In')).toBeInTheDocument();
     });
 
     it('shows dashboard and sign out when logged in', async () => {
       global.fetch = vi.fn(() =>
         Promise.resolve({
           ok: true,
-        } as Response)
+          json: () => Promise.resolve({ authenticated: true }),
+        } as unknown as Response)
       );
 
       render(<Navigation />);
-      
-      // Wait for auth check to complete
-      await new Promise(resolve => setTimeout(resolve, 100));
-      
-      const dashboardLink = screen.getByText('Dashboard');
-      const signOutButton = screen.getByText('Sign Out');
-      
-      expect(dashboardLink).toBeInTheDocument();
-      expect(signOutButton).toBeInTheDocument();
+
+      expect(await screen.findByText('Dashboard')).toBeInTheDocument();
+      expect(await screen.findByText('Sign Out')).toBeInTheDocument();
     });
   });
 });

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -13,12 +13,9 @@ export function Navigation() {
   useEffect(() => {
     if (isEmbed) return;
     fetch('/api/auth/me')
-      .then((res) => {
-        setIsLoggedIn(res.ok);
-      })
-      .catch(() => {
-        setIsLoggedIn(false);
-      });
+      .then((res) => res.json())
+      .then((data) => { setIsLoggedIn(data.authenticated === true); })
+      .catch(() => { setIsLoggedIn(false); });
   }, [pathname, isEmbed]);
 
   if (isEmbed) return null;


### PR DESCRIPTION
## Summary

- `GET /api/auth/me` was returning HTTP 401 when no session cookie was present, causing console errors on every page load for logged-out visitors
- Changed the no-session response to `200 { authenticated: false }` so the browser never logs a network error
- Updated all three callers to check `authJson.authenticated` instead of `res.ok`

## What changed

| File | Change |
|---|---|
| `app/api/auth/me/route.ts` | Returns `200 { authenticated: false }` instead of `401` when no session |
| `components/Navigation.tsx` | Parses JSON and checks `data.authenticated === true` |
| `app/shelf/[shelfId]/page.tsx` | Checks `authJson.authenticated` to determine owner |
| `app/shelf/[shelfId]/edit/page.tsx` | Redirects to `/login` on `!authJson.authenticated` |

## Test plan

- [ ] Visit the landing page while logged out — no 401 in the browser console
- [ ] Visit the login page while logged out — no 401 in the browser console
- [ ] Log in and visit a shelf — "Edit Shelf" button appears for the owner
- [ ] Log out and visit a shelf — "Edit Shelf" button is hidden
- [ ] Navigate directly to `/shelf/:id/edit` while logged out — redirects to `/login`

Fixes #166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)