### PR TITLE
fix: migrate hardcoded domain fallbacks to virtualbookshelf.app

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,13 +16,16 @@ const geistMono = Geist_Mono({
 });
 
 // Base URL for OG images
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.vercel.app';
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.app';
 
 export const metadata: Metadata = {
   title: "Virtual Bookshelf",
   description: "Curate and share your favorite books, podcasts, and music in a beautiful digital bookshelf.",
   keywords: ["bookshelf", "books", "podcasts", "music", "recommendations", "share", "curate"],
   authors: [{ name: "Virtual Bookshelf" }],
+  alternates: {
+    canonical: baseUrl,
+  },
   openGraph: {
     title: "Virtual Bookshelf - Your bookshelf, everywhere you are",
     description: "Curate your favorite books, podcasts, and music. Share a link anywhere.",

--- a/app/s/[shareToken]/page.tsx
+++ b/app/s/[shareToken]/page.tsx
@@ -54,7 +54,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       : `A curated collection of ${itemText} on Virtual Bookshelf`;
 
     // Get the base URL for OG image
-    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.vercel.app';
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.app';
     const ogImageUrl = `${baseUrl}/api/og/${shareToken}`;
 
     return {


### PR DESCRIPTION
## Summary

- Updated `baseUrl` fallback in `app/layout.tsx` from `virtualbookshelf.vercel.app` → `virtualbookshelf.app`
- Updated same fallback in `app/s/[shareToken]/page.tsx`
- Added `alternates: { canonical: baseUrl }` to the root metadata export in `app/layout.tsx` so search crawlers receive the correct canonical URL

## Context

The project is migrating from `virtualbookshelf.vercel.app` to the new custom domain `virtualbookshelf.app`. The `NEXT_PUBLIC_BASE_URL` env var in Vercel will be updated by the user. These fallback strings are the safety net for any environment where the env var isn't set (local dev, preview deploys, etc.).

## What was audited

- `app/layout.tsx` ✅ fixed
- `app/s/[shareToken]/page.tsx` ✅ fixed
- `app/page.tsx` — clean, no hardcoded URLs
- `app/api/og/[shareToken]/route.tsx` — `virtualbookshelf.app` appears as display text in the OG image footer; already correct, no change needed
- `app/api/og/landing/route.tsx` — no domain references, clean
- `lib/utils/schemaMarkup.ts` — no domain references, clean

## Test plan

- [ ] Build passes (`npm run build`) — verified ✅
- [ ] After merging, confirm `NEXT_PUBLIC_BASE_URL=https://virtualbookshelf.app` is set in Vercel dashboard
- [ ] Verify OG image URLs and canonical tag resolve to `virtualbookshelf.app` in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)