### PR TITLE
feat: SEO — sitemap, robots.txt, metadata fixes, and structured data

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,16 +19,19 @@ const geistMono = Geist_Mono({
 const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.app';
 
 export const metadata: Metadata = {
-  title: "Virtual Bookshelf",
-  description: "Curate and share your favorite books, podcasts, and music in a beautiful digital bookshelf.",
-  keywords: ["bookshelf", "books", "podcasts", "music", "recommendations", "share", "curate"],
+  title: {
+    default: 'Virtual Bookshelf',
+    template: '%s | Virtual Bookshelf',
+  },
+  description: 'Curate shelves of books, podcasts, music, videos, links — even live stock tickers. Share a single link anywhere.',
+  keywords: ['bookshelf', 'books', 'podcasts', 'music', 'videos', 'links', 'stocks', 'curate', 'share', 'reading list', 'watchlist'],
   authors: [{ name: "Virtual Bookshelf" }],
   alternates: {
-    canonical: baseUrl,
+    canonical: '/',
   },
   openGraph: {
-    title: "Virtual Bookshelf - Your bookshelf, everywhere you are",
-    description: "Curate your favorite books, podcasts, and music. Share a link anywhere.",
+    title: 'Virtual Bookshelf — A shelf for everything you love',
+    description: 'Curate shelves of books, podcasts, music, videos, links — even live stock tickers. Share a single link anywhere.',
     type: "website",
     siteName: "Virtual Bookshelf",
     locale: "en_US",
@@ -44,8 +47,8 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Virtual Bookshelf - Your bookshelf, everywhere you are",
-    description: "Curate your favorite books, podcasts, and music. Share a link anywhere.",
+    title: 'Virtual Bookshelf — A shelf for everything you love',
+    description: 'Curate shelves of books, podcasts, music, videos, links — even live stock tickers. Share a single link anywhere.',
     images: [`${baseUrl}/api/og/landing`],
   },
   icons: {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,26 @@ import { HOW_IT_WORKS } from '@/lib/constants/landingShowcase';
 const MAX_DEMO_SHELVES = 5;
 const MAX_ITEMS_PER_SHELF = 12;
 
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.app';
+
+const organizationSchema = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'Organization',
+      name: 'Virtual Bookshelf',
+      url: baseUrl,
+      logo: `${baseUrl}/favicon.svg`,
+    },
+    {
+      '@type': 'WebSite',
+      name: 'Virtual Bookshelf',
+      url: baseUrl,
+      description: 'Curate shelves of books, podcasts, music, videos, links and stocks. Share a single link anywhere.',
+    },
+  ],
+};
+
 /**
  * Fetch demo shelves for the home page
  *
@@ -55,6 +75,10 @@ export default async function Home() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900 flex flex-col">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationSchema) }}
+      />
       <main id="main-content" className="flex-1">
         {/* Hero */}
         <section className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-16 sm:pt-24 pb-10 text-center">

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,15 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.app'
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/dashboard', '/api/', '/embed/'],
+      },
+    ],
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,23 @@
+import { MetadataRoute } from 'next'
+import { getPublicShelves } from '@/lib/db/queries'
+
+export const dynamic = 'force-dynamic'
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.app'
+  const shelves = await getPublicShelves()
+
+  const shelfUrls = shelves.map(shelf => ({
+    url: `${baseUrl}/s/${shelf.share_token}`,
+    lastModified: shelf.updated_at,
+    changeFrequency: 'weekly' as const,
+    priority: 0.8,
+  }))
+
+  return [
+    { url: baseUrl, lastModified: new Date(), changeFrequency: 'daily', priority: 1 },
+    { url: `${baseUrl}/login`, changeFrequency: 'yearly', priority: 0.3 },
+    { url: `${baseUrl}/signup`, changeFrequency: 'yearly', priority: 0.3 },
+    ...shelfUrls,
+  ]
+}

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -431,6 +431,19 @@ export async function updateShelf(
 }
 
 /**
+ * Get all public shelves (for sitemap generation)
+ */
+export async function getPublicShelves(): Promise<{ share_token: string; updated_at: Date }[]> {
+  const result = await sql`
+    SELECT share_token, updated_at FROM shelves
+    WHERE is_public = true
+    ORDER BY updated_at DESC
+  `;
+
+  return result as { share_token: string; updated_at: Date }[];
+}
+
+/**
  * Delete shelf (cascades to items)
  */
 export async function deleteShelf(shelfId: string): Promise<boolean> {

--- a/lib/utils/schemaMarkup.ts
+++ b/lib/utils/schemaMarkup.ts
@@ -100,7 +100,7 @@ function sortItemsByOrder(items: Item[]): Item[] {
 function createCollectionSchema(shelf: Shelf, itemSchemas: SchemaObject[], username?: string | null): SchemaObject {
   const schema: SchemaObject = {
     '@context': 'https://schema.org',
-    '@type': 'Collection',
+    '@type': 'ItemList',
     name: shelf.name,
     itemListElement: itemSchemas,
     numberOfItems: itemSchemas.length,


### PR DESCRIPTION
Closes #167

## Summary

- **`app/sitemap.ts`** (new) — dynamic sitemap querying all public shelves from the DB; set `force-dynamic` so it renders on-demand rather than failing at build time
- **`app/robots.ts`** (new) — disallows `/dashboard`, `/api/`, `/embed/`; points crawlers to the sitemap
- **`lib/db/queries.ts`** — added `getPublicShelves()` (returns `share_token` + `updated_at` for all `is_public = true` shelves)
- **`app/layout.tsx`** — title is now a template (`%s | Virtual Bookshelf`); description updated to include videos/links/stocks; OG and Twitter titles aligned to hero headline ("A shelf for everything you love"); canonical changed to `'/'`
- **`lib/utils/schemaMarkup.ts`** — fixed `'@type': 'Collection'` → `'@type': 'ItemList'` (Collection is not a valid schema.org type; ItemList is supported by Google rich results)
- **`app/page.tsx`** — added Organization + WebSite JSON-LD `<script>` tag to the homepage

## Test plan

- [ ] `npm run build` passes (verified locally — all 32 static pages generated, `/sitemap.xml` is dynamic, `/robots.txt` is static)
- [ ] `/sitemap.xml` on production returns XML with shelf URLs
- [ ] `/robots.txt` on production returns correct disallow rules
- [ ] No TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)