### PR TITLE
feat: landing page — FAQ section + JSON-LD schema, and "Embed it anywhere" section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -85,9 +85,60 @@ async function getDemoShelvesData(): Promise<ShelfPreview[] | null> {
   }
 }
 
+/**
+ * The "public link" bar shown in the Embed section. When a real demo shelf is
+ * available it renders as a link that clicks through to the live shelf (just
+ * like the preview cards); otherwise it falls back to a static placeholder.
+ */
+function EmbedLinkBar({ url, href }: { url: string; href: string | null }) {
+  const base =
+    'flex items-center gap-3 rounded-xl border border-gray-200 dark:border-gray-800 bg-white/70 dark:bg-gray-900/60 px-4 py-3.5 shadow-sm';
+  const inner = (
+    <>
+      <svg
+        className="w-5 h-5 shrink-0 text-gray-400 dark:text-gray-500"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.8}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M10 13a5 5 0 0 0 7 0l2-2a5 5 0 0 0-7-7l-1 1" />
+        <path d="M14 11a5 5 0 0 0-7 0l-2 2a5 5 0 0 0 7 7l1-1" />
+      </svg>
+      <span className="font-mono text-sm text-gray-700 dark:text-gray-300 truncate">{url}</span>
+      <span className="ml-auto text-xs font-medium text-gray-400 dark:text-gray-500 whitespace-nowrap transition-colors group-hover:text-gray-600 dark:group-hover:text-gray-400">
+        {href ? 'Click to explore →' : 'Public link'}
+      </span>
+    </>
+  );
+
+  if (href) {
+    return (
+      <Link
+        href={href}
+        className={`${base} group transition hover:border-gray-300 dark:hover:border-gray-700 hover:shadow-md`}
+      >
+        {inner}
+      </Link>
+    );
+  }
+  return <div className={base}>{inner}</div>;
+}
+
 export default async function Home() {
   const demoShelves = await getDemoShelvesData();
   const hasDemo = Boolean(demoShelves && demoShelves.length > 0);
+
+  // Use a real demo shelf for the Embed section's example link so it clicks
+  // through to a live shelf, just like the preview cards. Falls back to a
+  // placeholder when no demo data is available (e.g. local dev without env).
+  const embedExampleToken = demoShelves?.[0]?.shelf.share_token ?? null;
+  const embedExampleUrl = embedExampleToken
+    ? `${baseUrl.replace(/^https?:\/\//, '')}/s/${embedExampleToken}`
+    : SHELF_LINK_EXAMPLE;
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900 flex flex-col">
@@ -187,28 +238,11 @@ export default async function Home() {
             </div>
 
             <div className="max-w-xl mx-auto">
-              {/* The link — the no-code path */}
-              <div className="flex items-center gap-3 rounded-xl border border-gray-200 dark:border-gray-800 bg-white/70 dark:bg-gray-900/60 px-4 py-3.5 shadow-sm">
-                <svg
-                  className="w-5 h-5 shrink-0 text-gray-400 dark:text-gray-500"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth={1.8}
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  aria-hidden="true"
-                >
-                  <path d="M10 13a5 5 0 0 0 7 0l2-2a5 5 0 0 0-7-7l-1 1" />
-                  <path d="M14 11a5 5 0 0 0-7 0l-2 2a5 5 0 0 0 7 7l1-1" />
-                </svg>
-                <span className="font-mono text-sm text-gray-700 dark:text-gray-300 truncate">
-                  {SHELF_LINK_EXAMPLE}
-                </span>
-                <span className="ml-auto text-xs font-medium text-gray-400 dark:text-gray-500 whitespace-nowrap">
-                  Public link
-                </span>
-              </div>
+              {/* The link — the no-code path, clicks through to a live shelf */}
+              <EmbedLinkBar
+                url={embedExampleUrl}
+                href={embedExampleToken ? `/s/${embedExampleToken}` : null}
+              />
 
               {/* Where it works */}
               <div className="mt-5 flex flex-wrap items-center justify-center gap-2">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -42,7 +42,8 @@ const organizationSchema = {
   ],
 };
 
-const EMBED_DESTINATIONS = ['Custom sites', 'Notion', 'Squarespace', 'Any HTML page'];
+const EMBED_DESTINATIONS = ['Notion', 'Squarespace', 'Webflow', 'WordPress'];
+const SHELF_LINK_EXAMPLE = `${baseUrl.replace(/^https?:\/\//, '')}/s/your-shelf`;
 
 /**
  * Fetch demo shelves for the home page
@@ -179,26 +180,38 @@ export default async function Home() {
                 Embed it anywhere
               </h2>
               <p className="mt-3 text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
-                Drop a live shelf or playlist straight into your own website or a
-                Notion page. Paste one snippet and it stays in sync — update the
-                shelf, and every embed updates with it.
+                Every shelf gets a public link. Drop it into Notion or a site builder
+                and it embeds live — cover art, metadata, and prices included. Change
+                the shelf, and every embed updates with it.
               </p>
             </div>
 
-            <div className="max-w-2xl mx-auto">
-              <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white/70 dark:bg-gray-900/60 overflow-hidden shadow-sm">
-                <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-gray-200 dark:border-gray-800">
-                  <span className="w-2.5 h-2.5 rounded-full bg-gray-300 dark:bg-gray-700" aria-hidden="true" />
-                  <span className="w-2.5 h-2.5 rounded-full bg-gray-300 dark:bg-gray-700" aria-hidden="true" />
-                  <span className="w-2.5 h-2.5 rounded-full bg-gray-300 dark:bg-gray-700" aria-hidden="true" />
-                  <span className="ml-2 text-xs font-medium text-gray-400 dark:text-gray-500">Embed code</span>
-                </div>
-                <pre className="px-4 py-4 overflow-x-auto text-xs sm:text-sm font-mono text-gray-700 dark:text-gray-300">
-                  <code>{`<iframe\n  src="${baseUrl}/embed/your-shelf"\n  width="100%" height="600" loading="lazy"\n></iframe>`}</code>
-                </pre>
+            <div className="max-w-xl mx-auto">
+              {/* The link — the no-code path */}
+              <div className="flex items-center gap-3 rounded-xl border border-gray-200 dark:border-gray-800 bg-white/70 dark:bg-gray-900/60 px-4 py-3.5 shadow-sm">
+                <svg
+                  className="w-5 h-5 shrink-0 text-gray-400 dark:text-gray-500"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.8}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M10 13a5 5 0 0 0 7 0l2-2a5 5 0 0 0-7-7l-1 1" />
+                  <path d="M14 11a5 5 0 0 0-7 0l-2 2a5 5 0 0 0 7 7l1-1" />
+                </svg>
+                <span className="font-mono text-sm text-gray-700 dark:text-gray-300 truncate">
+                  {SHELF_LINK_EXAMPLE}
+                </span>
+                <span className="ml-auto text-xs font-medium text-gray-400 dark:text-gray-500 whitespace-nowrap">
+                  Public link
+                </span>
               </div>
 
-              <div className="mt-6 flex flex-wrap items-center justify-center gap-2">
+              {/* Where it works */}
+              <div className="mt-5 flex flex-wrap items-center justify-center gap-2">
                 {EMBED_DESTINATIONS.map((dest) => (
                   <span
                     key={dest}
@@ -207,6 +220,26 @@ export default async function Home() {
                     {dest}
                   </span>
                 ))}
+              </div>
+
+              {/* The custom-site path, demoted */}
+              <p className="mt-6 text-center text-sm text-gray-500 dark:text-gray-400">
+                Building a custom site? Grab a ready-made{' '}
+                <code className="font-mono text-[0.8125rem] text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 rounded px-1.5 py-0.5">
+                  &lt;iframe&gt;
+                </code>{' '}
+                from any shelf&apos;s Share menu.
+              </p>
+
+              {/* Somewhere to go */}
+              <div className="mt-8 text-center">
+                <Link
+                  href="/signup"
+                  className="inline-flex items-center gap-1.5 font-medium text-gray-900 dark:text-gray-100 hover:underline"
+                >
+                  Create a shelf and grab your link
+                  <span aria-hidden="true">→</span>
+                </Link>
               </div>
             </div>
           </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -42,6 +42,8 @@ const organizationSchema = {
   ],
 };
 
+const EMBED_DESTINATIONS = ['Custom sites', 'Notion', 'Squarespace', 'Any HTML page'];
+
 /**
  * Fetch demo shelves for the home page
  *
@@ -168,6 +170,45 @@ export default async function Home() {
                 </li>
               ))}
             </ol>
+          </section>
+
+          {/* Embed anywhere */}
+          <section aria-labelledby="embed-heading" className="mb-20 sm:mb-28">
+            <div className="text-center mb-10">
+              <h2 id="embed-heading" className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 tracking-tight">
+                Embed it anywhere
+              </h2>
+              <p className="mt-3 text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
+                Drop a live shelf or playlist straight into your own website or a
+                Notion page. Paste one snippet and it stays in sync — update the
+                shelf, and every embed updates with it.
+              </p>
+            </div>
+
+            <div className="max-w-2xl mx-auto">
+              <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white/70 dark:bg-gray-900/60 overflow-hidden shadow-sm">
+                <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-gray-200 dark:border-gray-800">
+                  <span className="w-2.5 h-2.5 rounded-full bg-gray-300 dark:bg-gray-700" aria-hidden="true" />
+                  <span className="w-2.5 h-2.5 rounded-full bg-gray-300 dark:bg-gray-700" aria-hidden="true" />
+                  <span className="w-2.5 h-2.5 rounded-full bg-gray-300 dark:bg-gray-700" aria-hidden="true" />
+                  <span className="ml-2 text-xs font-medium text-gray-400 dark:text-gray-500">Embed code</span>
+                </div>
+                <pre className="px-4 py-4 overflow-x-auto text-xs sm:text-sm font-mono text-gray-700 dark:text-gray-300">
+                  <code>{`<iframe\n  src="${baseUrl}/embed/your-shelf"\n  width="100%" height="600" loading="lazy"\n></iframe>`}</code>
+                </pre>
+              </div>
+
+              <div className="mt-6 flex flex-wrap items-center justify-center gap-2">
+                {EMBED_DESTINATIONS.map((dest) => (
+                  <span
+                    key={dest}
+                    className="px-3 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-700"
+                  >
+                    {dest}
+                  </span>
+                ))}
+              </div>
+            </div>
           </section>
 
           {/* FAQ */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,19 @@ const MAX_ITEMS_PER_SHELF = 12;
 
 const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.app';
 
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    { '@type': 'Question', name: 'What is Virtual Bookshelf?', acceptedAnswer: { '@type': 'Answer', text: 'Virtual Bookshelf is a tool to curate and share shelves of books, podcasts, music, videos, links, and live stock tickers. Create a shelf, get a shareable link, and paste it anywhere — your bio, newsletter, LinkedIn, or portfolio.' } },
+    { '@type': 'Question', name: 'What can I put on a shelf?', acceptedAnswer: { '@type': 'Answer', text: 'Books, podcasts, podcast episodes, music albums, YouTube videos, any link, and live stock tickers.' } },
+    { '@type': 'Question', name: 'How do I share my shelf?', acceptedAnswer: { '@type': 'Answer', text: 'Every shelf gets a public link. Paste it in your bio, newsletter, LinkedIn, or anywhere you want people to find it.' } },
+    { '@type': 'Question', name: 'Is Virtual Bookshelf free?', acceptedAnswer: { '@type': 'Answer', text: 'Yes, Virtual Bookshelf is free to use.' } },
+    { '@type': 'Question', name: 'What happened to Bento.me?', acceptedAnswer: { '@type': 'Answer', text: 'Bento.me shut down in February 2026 after being acquired by Linktree. Virtual Bookshelf is a great alternative for creators who want to showcase what they are reading, watching, and listening to with rich cover art and metadata.' } },
+    { '@type': 'Question', name: 'How is Virtual Bookshelf different from Linktree?', acceptedAnswer: { '@type': 'Answer', text: 'Linktree shows a list of links. Virtual Bookshelf shows rich content — cover art, metadata, and live prices — for everything on your shelf.' } },
+  ],
+};
+
 const organizationSchema = {
   '@context': 'https://schema.org',
   '@graph': [
@@ -78,6 +91,10 @@ export default async function Home() {
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
       />
       <main id="main-content" className="flex-1">
         {/* Hero */}
@@ -151,6 +168,25 @@ export default async function Home() {
                 </li>
               ))}
             </ol>
+          </section>
+
+          {/* FAQ */}
+          <section aria-labelledby="faq-heading" className="max-w-2xl mx-auto mb-20 sm:mb-28">
+            <h2 id="faq-heading" className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 tracking-tight text-center mb-10">
+              Frequently asked questions
+            </h2>
+            <dl className="space-y-8">
+              {faqSchema.mainEntity.map((item) => (
+                <div key={item.name}>
+                  <dt className="font-semibold text-gray-900 dark:text-gray-100 text-base sm:text-lg">
+                    {item.name}
+                  </dt>
+                  <dd className="mt-2 text-gray-600 dark:text-gray-400 leading-relaxed">
+                    {item.acceptedAnswer.text}
+                  </dd>
+                </div>
+              ))}
+            </dl>
           </section>
 
           {/* Final CTA */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -133,10 +133,10 @@ export default async function Home() {
   const hasDemo = Boolean(demoShelves && demoShelves.length > 0);
 
   // Use a real demo shelf for the Embed section's example link so it clicks
-  // through to a live shelf, just like the preview cards. Uses the second shelf
-  // in the admin user's public set; falls back to a placeholder when fewer than
-  // two demo shelves are available (e.g. local dev without env).
-  const embedExampleToken = demoShelves?.[1]?.shelf.share_token ?? null;
+  // through to a live shelf, just like the preview cards. Uses the first shelf
+  // in the admin user's public set; falls back to a placeholder when no demo
+  // data is available (e.g. local dev without env).
+  const embedExampleToken = demoShelves?.[0]?.shelf.share_token ?? null;
   const embedExampleUrl = embedExampleToken
     ? `${baseUrl.replace(/^https?:\/\//, '')}/s/${embedExampleToken}`
     : SHELF_LINK_EXAMPLE;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -133,9 +133,10 @@ export default async function Home() {
   const hasDemo = Boolean(demoShelves && demoShelves.length > 0);
 
   // Use a real demo shelf for the Embed section's example link so it clicks
-  // through to a live shelf, just like the preview cards. Falls back to a
-  // placeholder when no demo data is available (e.g. local dev without env).
-  const embedExampleToken = demoShelves?.[0]?.shelf.share_token ?? null;
+  // through to a live shelf, just like the preview cards. Uses the second shelf
+  // in the admin user's public set; falls back to a placeholder when fewer than
+  // two demo shelves are available (e.g. local dev without env).
+  const embedExampleToken = demoShelves?.[1]?.shelf.share_token ?? null;
   const embedExampleUrl = embedExampleToken
     ? `${baseUrl.replace(/^https?:\/\//, '')}/s/${embedExampleToken}`
     : SHELF_LINK_EXAMPLE;

--- a/public/google53871408a73f9098.html
+++ b/public/google53871408a73f9098.html
@@ -1,0 +1,1 @@
+google-site-verification: google53871408a73f9098.html


### PR DESCRIPTION
## Summary

Two additions to the landing page (`app/page.tsx`), both isolated to that one file.

### 1. FAQ section + JSON-LD schema (closes #172)
- Adds a `FAQPage` JSON-LD `<script>` tag alongside the existing Organization/WebSite schema
- Adds a visible `<dl>`-based FAQ section (6 Q&A pairs) above the Final CTA, styled to match the existing landing page aesthetic (centered, `max-w-2xl`, same font sizing)

### 2. "Embed it anywhere" section
New section between "How it works" and the FAQ, reframed for the no-code creator audience:
- **Leads with the public shelf link** — the actual easy path for Notion and most site builders (you paste a URL, not HTML). Shown as a friendly URL bar rather than raw iframe code.
- **Destination pills** — Notion · Squarespace · Webflow · WordPress
- **Demotes the `<iframe>`** to a one-line note for custom sites, pointing to where it's generated (the Share menu / `ShareModal`)
- **Ends with a CTA** ("Create a shelf and grab your link →") so the section drives an action instead of dead-ending
- Server-rendered, no new client component

## Verification
- [x] `npm run build` passes with no errors
- [x] Rendered in the dev preview across **desktop light, desktop dark, and mobile (390px)** — correct positioning, link bar fits without truncation, pills wrap cleanly, no console errors
- [ ] (Optional) Validate FAQ schema via Google's Rich Results Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)