### PR TITLE
feat: track shelf creation, signups, and logins in Vercel Analytics

### DIFF
--- a/app/api/auth/google/callback/route.ts
+++ b/app/api/auth/google/callback/route.ts
@@ -8,6 +8,7 @@ import {
 } from '@/lib/db/queries';
 import { setSessionCookie } from '@/lib/utils/session';
 import { createLogger } from '@/lib/utils/logger';
+import { trackServerEvent } from '@/lib/utils/analytics';
 
 const logger = createLogger('OAuthCallback');
 
@@ -107,6 +108,7 @@ export async function GET(request: Request) {
 
     // Check if user exists
     let user = await getUserByEmail(email);
+    const isNewUser = !user;
 
     if (!user) {
       // Create new user
@@ -128,10 +130,19 @@ export async function GET(request: Request) {
         googleId,
         name,
       });
+
+      // Track account creation as a custom event in Vercel Analytics
+      // (only on the new-user branch — existing users here are logins/links)
+      await trackServerEvent('Account Created', { method: 'google' }, request);
     } else if (!user.google_id) {
       // Link Google to existing account
       logger.debug('Linking Google account to existing user');
       user = await updateUserGoogleId(user.id, googleId);
+    }
+
+    // Existing users reaching this point are logging in, not signing up
+    if (!isNewUser) {
+      await trackServerEvent('User Login', { method: 'google' }, request);
     }
 
     // Set session cookie

--- a/app/api/auth/login/route.test.ts
+++ b/app/api/auth/login/route.test.ts
@@ -18,6 +18,10 @@ vi.mock('@/lib/utils/session', () => ({
   setSessionCookie: vi.fn(),
 }));
 
+vi.mock('@/lib/utils/analytics', () => ({
+  trackServerEvent: vi.fn(),
+}));
+
 import { getUserByUsername } from '@/lib/db/queries';
 import { verifyPassword } from '@/lib/utils/password';
 import { setSessionCookie } from '@/lib/utils/session';

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -10,6 +10,7 @@ import {
   isRateLimitingEnabled 
 } from '@/lib/utils/rateLimit';
 import { createLogger } from '@/lib/utils/logger';
+import { trackServerEvent } from '@/lib/utils/analytics';
 
 const logger = createLogger('AuthLogin');
 
@@ -78,6 +79,9 @@ export async function POST(request: Request) {
       username: user.username,
       email: user.email,
     });
+
+    // Track login as a custom event in Vercel Analytics
+    await trackServerEvent('User Login', { method: 'email' }, request);
 
     return NextResponse.json({
       success: true,

--- a/app/api/auth/signup/route.test.ts
+++ b/app/api/auth/signup/route.test.ts
@@ -20,6 +20,10 @@ vi.mock('@/lib/utils/session', () => ({
   setSessionCookie: vi.fn(),
 }));
 
+vi.mock('@/lib/utils/analytics', () => ({
+  trackServerEvent: vi.fn(),
+}));
+
 import { getUserByUsername, getUserByEmail, createUser } from '@/lib/db/queries';
 import { hashPassword } from '@/lib/utils/password';
 import { setSessionCookie } from '@/lib/utils/session';

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -10,6 +10,7 @@ import {
   isRateLimitingEnabled 
 } from '@/lib/utils/rateLimit';
 import { createLogger } from '@/lib/utils/logger';
+import { trackServerEvent } from '@/lib/utils/analytics';
 
 const logger = createLogger('AuthSignup');
 
@@ -84,6 +85,9 @@ export async function POST(request: Request) {
     });
 
     logger.debug('New user created', { userId: user.id, username: user.username });
+
+    // Track account creation as a custom event in Vercel Analytics
+    await trackServerEvent('Account Created', { method: 'email' }, request);
 
     // Set session cookie
     await setSessionCookie({

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { track } from '@vercel/analytics';
 import { EmptyState, BookshelfIcon } from '@/components/ui/EmptyState';
 import { SkeletonShelfGrid } from '@/components/ui/SkeletonLoader';
 import { AddItemModal } from '@/components/shelf/AddItemModal';
@@ -87,6 +88,9 @@ export default function DashboardClient() {
         setCreatingShelf(false);
         return;
       }
+
+      // Track shelf creation as a custom event in Vercel Analytics
+      track('Shelf Created', { has_description: Boolean(shelfDescription) });
 
       // Store new shelf info for modal
       setNewShelfId(json.data.id);

--- a/lib/utils/analytics.ts
+++ b/lib/utils/analytics.ts
@@ -1,0 +1,31 @@
+import { track } from '@vercel/analytics/server';
+import { createLogger } from './logger';
+
+const logger = createLogger('Analytics');
+
+type EventProperties = Record<string, string | number | boolean | null>;
+
+/**
+ * Fire a Vercel Analytics custom event from a server route handler.
+ *
+ * Non-fatal by design: any analytics failure is logged and swallowed so it can
+ * never break the request flow (e.g. account creation must still succeed even
+ * if tracking the event fails). Passing the originating `request` lets Vercel
+ * attribute the event correctly (geo, path, etc.).
+ *
+ * Custom events appear under Analytics → Events in the Vercel dashboard.
+ */
+export async function trackServerEvent(
+  name: string,
+  properties: EventProperties,
+  request?: Request,
+): Promise<void> {
+  try {
+    await track(name, properties, request ? { headers: request.headers } : undefined);
+  } catch (error) {
+    logger.warn('Failed to track analytics event', {
+      event: name,
+      error: error instanceof Error ? error.message : 'unknown',
+    });
+  }
+}


### PR DESCRIPTION
## What

Adds Vercel Analytics **custom events** so core product metrics show up under **Analytics → Events** in the Vercel dashboard:

| Event | Properties | Fired |
|-------|-----------|-------|
| `Shelf Created` | `has_description` | Client-side, dashboard create flow |
| `Account Created` | `method: email \| google` | Server-side, email signup + new Google OAuth users |
| `User Login` | `method: email \| google` | Server-side, email login + returning Google users |

## Why

We had `@vercel/analytics` mounted for page views but no product metrics. These events let us track growth (signups, shelves) and engagement (logins) over time, with `method` / `has_description` breakdowns.

## How

- New shared helper [`lib/utils/analytics.ts`](lib/utils/analytics.ts) — `trackServerEvent(name, props, request)` forwards request headers for proper attribution and **swallows failures** (logged, not thrown) so analytics can never break the auth path.
- Shelf event is client-side because the dashboard is its only creation path; account/login events are server-side because the Google OAuth path is a redirect with no client fetch.
- In the Google callback, `isNewUser` is captured **before** the user record is mutated, so new signups fire `Account Created` and existing users (including first-time Google→email links) fire `User Login` — no double-counting.

## Reviewer notes

- Custom events only record on Vercel infra; `track()` is a no-op locally, so there's nothing to verify in a local preview. They appear post-deploy in the dashboard and are **forward-going** (not historical).
- Login/signup route tests get an `@/lib/utils/analytics` mock to stay hermetic.

## Verification

- ✅ 24/24 auth route tests pass (login + signup)
- ✅ ESLint clean on all changed files
- ✅ No new `tsc` errors (pre-existing test-file type warnings unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)