### PR TITLE
fix: correct canonical tags and page titles for SEO indexability

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,16 +19,14 @@ const geistMono = Geist_Mono({
 const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.app';
 
 export const metadata: Metadata = {
+  metadataBase: new URL(baseUrl),
   title: {
-    default: 'Virtual Bookshelf',
+    default: 'Virtual Bookshelf — your books, podcasts & music in one link',
     template: '%s | Virtual Bookshelf',
   },
   description: 'Curate shelves of books, podcasts, music, videos, links — even live stock tickers. Share a single link anywhere.',
   keywords: ['bookshelf', 'books', 'podcasts', 'music', 'videos', 'links', 'stocks', 'curate', 'share', 'reading list', 'watchlist'],
   authors: [{ name: "Virtual Bookshelf" }],
-  alternates: {
-    canonical: '/',
-  },
   openGraph: {
     title: 'Virtual Bookshelf — A shelf for everything you love',
     description: 'Curate shelves of books, podcasts, music, videos, links — even live stock tickers. Share a single link anywhere.',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,13 @@ const MAX_ITEMS_PER_SHELF = 12;
 
 const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.app';
 
+// Self-referential canonical for the home page. Without this, the page would
+// emit no canonical (the global one was removed to stop subpages inheriting it),
+// so be explicit to consolidate any UTM/social variants back to the root.
+export const metadata = {
+  alternates: { canonical: '/' },
+};
+
 const faqSchema = {
   '@context': 'https://schema.org',
   '@type': 'FAQPage',

--- a/app/s/[shareToken]/page.tsx
+++ b/app/s/[shareToken]/page.tsx
@@ -39,8 +39,9 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     
     if (!shelf || !shelf.is_public) {
       return {
-        title: 'Shelf Not Found | Virtual Bookshelf',
+        title: 'Shelf Not Found',
         description: 'This shelf could not be found.',
+        robots: { index: false },
       };
     }
 
@@ -58,8 +59,9 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     const ogImageUrl = `${baseUrl}/api/og/${shareToken}`;
 
     return {
-      title: `${shelf.name} | Virtual Bookshelf`,
+      title: shelf.name,
       description,
+      alternates: { canonical: `/s/${shareToken}` },
       openGraph: {
         title: shelf.name,
         description,
@@ -85,7 +87,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   } catch (error) {
     console.error('Error generating metadata:', error);
     return {
-      title: 'Virtual Bookshelf',
+      title: { absolute: 'Virtual Bookshelf' },
       description: 'Curate and share your favorite books, podcasts, and music.',
     };
   }


### PR DESCRIPTION
The root layout set a global canonical of '/', which Next.js inherited to every route, so all public shelf pages (/s/[token]) canonicalized to the homepage and were effectively de-indexed. Remove the global canonical and set self-referential canonicals per page (/, /s/<token>), add metadataBase so they resolve to absolute URLs, give the homepage a descriptive keyword-rich title, de-duplicate the doubled '| Virtual Bookshelf | Virtual Bookshelf' shelf titles, and noindex not-found shelves.