### PR TITLE
feat: llms.txt + site-wide Organization sameAs schema (AEO)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,6 +18,23 @@ const geistMono = Geist_Mono({
 // Base URL for OG images
 const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.app';
 
+// Site-wide Organization entity with sameAs profile links, so search and answer
+// engines can resolve "Virtual Bookshelf" as a distinct entity (the brand name is
+// contested). Rendered on every page from the root layout below.
+const organizationSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  '@id': `${baseUrl}/#organization`,
+  name: 'Virtual Bookshelf',
+  url: baseUrl,
+  logo: `${baseUrl}/favicon.svg`,
+  description:
+    'Curate and share shelves of books, podcasts, music, videos, links, and live stock tickers — all behind one link.',
+  sameAs: [
+    'https://github.com/arielwernick/virtual_bookshelf',
+  ],
+};
+
 export const metadata: Metadata = {
   metadataBase: new URL(baseUrl),
   title: {
@@ -74,6 +91,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100`}
       >
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationSchema) }}
+        />
         <Providers>
           <Navigation />
           {children}

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,0 +1,46 @@
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.app';
+
+/**
+ * Served at /llms.txt — guidance for AI crawlers and answer engines (llmstxt.org).
+ *
+ * Standalone from the marketing pages: it lists the canonical URLs and the key
+ * facts so engines like ChatGPT, Perplexity, and Google AI Overviews can
+ * summarize and cite the product accurately.
+ */
+export function GET() {
+  const body = `# Virtual Bookshelf
+
+> Virtual Bookshelf is a free tool for curating and sharing shelves of books, podcasts, music, videos, links, and live stock tickers. Create a shelf, get one shareable link, and paste it anywhere — a bio, newsletter, or website. Search a title or paste a URL and the cover art and details are filled in automatically.
+
+Virtual Bookshelf is a link-in-bio tool built for rich media instead of plain links. It is a popular alternative to Bento.me (which shut down in February 2026), Linktree, and Goodreads for people who want to show what they read, watch, and listen to.
+
+## Key pages
+
+- [Home](${baseUrl}/): Create and share a shelf of the books, podcasts, music, and videos you love.
+- [Bento.me alternative](${baseUrl}/bento-alternative): Why Virtual Bookshelf is a strong replacement after Bento.me shut down on February 13, 2026.
+- [Linktree alternative](${baseUrl}/linktree-alternative): A link in bio that shows rich visual cards instead of a list of links.
+- [Goodreads alternative](${baseUrl}/goodreads-alternative): A beautiful, shareable bookshelf you control — for curating and sharing, not reviews or tracking.
+
+## What you can put on a shelf
+
+- Books — search millions of titles; cover art is added automatically
+- Podcasts and individual podcast episodes
+- Music albums and tracks
+- YouTube videos
+- Any link — the title, image, and source are pulled in automatically
+- Live stock tickers — with a live price, a one-year chart, and recent headlines
+
+## Facts
+
+- Price: free to use.
+- Sharing: every shelf has a public link and can be embedded on your own site (Notion, Webflow, WordPress, Squarespace, and more).
+- Bento.me: shut down on February 13, 2026 after being acquired by Linktree; its pages now redirect to Linktree.
+`;
+
+  return new Response(body, {
+    headers: {
+      'content-type': 'text/plain; charset=utf-8',
+      'cache-control': 'public, max-age=3600, must-revalidate',
+    },
+  });
+}


### PR DESCRIPTION
## What

Two standalone AEO (answer-engine) improvements — neither touches the landing page.

- **`/llms.txt`** — a guidance file for AI crawlers and answer engines (llmstxt.org format): a one-line summary, links to the canonical pages, supported item types, and key facts (including the Bento.me shutdown). Served as a route handler so the URLs track `NEXT_PUBLIC_BASE_URL`.
- **Site-wide `Organization` schema** — JSON-LD with a stable `@id` and `sameAs` added to the **root layout**, so it renders on every page and helps search/answer engines resolve "Virtual Bookshelf" as a distinct entity (the brand name collides with several other apps).

## Why

AI engines (ChatGPT, Perplexity, Google AI Overviews) increasingly read `llms.txt` and lean on entity signals + structured data to cite sources accurately. Together these make the product easier to summarize correctly and attribute.

## Notes / follow-ups

- **`sameAs` seed:** currently lists the GitHub repo (the one verifiable profile). Add X / LinkedIn / Instagram URLs to strengthen it — a one-line change in `app/layout.tsx`.
- **Minor redundancy:** the homepage now carries the layout's `Organization` (with `sameAs`) plus its pre-existing inline `Organization` in `app/page.tsx`. Harmless — Google merges them by `@id`/name — and left as-is to keep `app/page.tsx` untouched per the "keep the landing page clean" preference. Happy to consolidate if wanted.

## Verification

- `tsc --noEmit` and ESLint clean
- Dev server: `/llms.txt` → `200`, `text/plain`, valid llms.txt markdown; `Organization` + `sameAs` present on both `/` and `/bento-alternative` (confirms site-wide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
