### PR TITLE
Add SEO/AEO landing pages for conference resources and embed feature

### DIFF
--- a/app/curate-conference-resources/page.tsx
+++ b/app/curate-conference-resources/page.tsx
@@ -1,0 +1,163 @@
+import type { Metadata } from 'next';
+import { AlternativeLandingPage } from '@/components/landing/AlternativeLandingPage';
+import { faqPageJsonLd, breadcrumbJsonLd, type FaqItem } from '@/lib/utils/landingSchema';
+
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.app';
+
+export const metadata: Metadata = {
+  title: 'Share Conference Resources & Event Recaps — Virtual Bookshelf',
+  description:
+    'Turn your conference talk list into a shareable, visual resource shelf. Add speaker recordings, articles, and links — cover art and titles fill in automatically. One link to share with your community.',
+  alternates: { canonical: '/curate-conference-resources' },
+  openGraph: {
+    title: 'Share Conference Resources as a Beautiful Shelf',
+    description:
+      'Stop sharing flat link lists. Virtual Bookshelf turns your conference recap into a visual, browsable resource page — recordings, articles, and speaker links all in one place.',
+    type: 'website',
+    url: `${baseUrl}/curate-conference-resources`,
+    siteName: 'Virtual Bookshelf',
+    images: [{ url: `${baseUrl}/api/og/landing`, width: 1200, height: 630, alt: 'Virtual Bookshelf — share conference resources' }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Share Conference Resources as a Beautiful Shelf',
+    description:
+      'Turn your conference recap into a visual resource shelf — recordings, articles, and links in one shareable page.',
+    images: [`${baseUrl}/api/og/landing`],
+  },
+};
+
+const FAQ: FaqItem[] = [
+  {
+    q: 'What is the best way to share conference resources online?',
+    a: 'The best way is to collect all recordings, articles, and speaker links into a single visual shelf — rather than a flat list of links in a LinkedIn post or newsletter. A shelf is browsable, shareable with one URL, and auto-fills thumbnails and titles so your community can quickly find what they care about.',
+  },
+  {
+    q: 'How do I organize talks and recordings from an event?',
+    a: 'Add each talk or recording to a Virtual Bookshelf shelf by pasting the URL or searching by title. The shelf automatically pulls in the video thumbnail, title, speaker name, and description. You can add a note to each item with your own takeaway, then share the whole shelf with one link.',
+  },
+  {
+    q: 'Can I share a curated list of conference talks on LinkedIn?',
+    a: 'Yes — and a shelf link looks much better than a wall of text. Paste your shelf URL into a LinkedIn post and the Open Graph preview shows a clean, branded image. Your followers get one click to a browsable, visual resource page instead of scanning through a long caption.',
+  },
+  {
+    q: 'Is there a free tool for sharing event recap resources?',
+    a: 'Virtual Bookshelf is free. Create a shelf, add your conference talks and links, and share the URL — no credit card required. Rich cards with cover art and titles generate automatically.',
+  },
+  {
+    q: 'Can I embed a conference resource shelf on my website or newsletter?',
+    a: 'Yes. Every shelf has an embeddable version you can drop into Notion, Webflow, Substack, or any site that accepts an iframe. It stays live — when you add or update items, the embedded shelf updates too.',
+  },
+  {
+    q: 'Who uses Virtual Bookshelf for conference resources?',
+    a: 'Event organizers collecting speaker recordings, newsletter writers curating the best talks from an event, community managers sharing resources after a summit, and individual attendees building their own personal recap shelf.',
+  },
+];
+
+export default function CurateConferenceResourcesPage() {
+  return (
+    <AlternativeLandingPage
+      breadcrumbLabel="Curate conference resources"
+      h1="Turn your conference recap into a shareable resource shelf"
+      heroSubhead="Stop sharing flat lists of links. Add your talks, recordings, and articles — cover art and titles fill in automatically — then share one beautiful URL with your community."
+      intro={{
+        heading: 'What is the best way to share conference resources?',
+        paragraphs: [
+          'After a great event, the instinct is to paste every link into a LinkedIn post or newsletter. The result is a wall of text that nobody saves and most people skip.',
+          'A Virtual Bookshelf shelf does the same thing visually — each talk or article becomes a rich card with a thumbnail, title, and your own note. Share one URL and your audience can browse, click, and bookmark what matters to them.',
+        ],
+      }}
+      reasons={{
+        heading: 'Built for the way people actually share event resources',
+        sub: 'Rich cards, automatic metadata, one link — everything a flat post is not.',
+        items: [
+          {
+            title: 'Visual cards, not a link dump',
+            body: 'Every recording, article, or speaker link becomes a card with a real thumbnail and title — far easier to scan than a bulleted list.',
+          },
+          {
+            title: 'Metadata fills in automatically',
+            body: 'Paste a YouTube link, a newsletter article, or a podcast episode URL and the title, thumbnail, and description populate themselves. No manual work.',
+          },
+          {
+            title: 'One link for everything',
+            body: 'Share a single URL in your post, bio, or email. Embed the live shelf in Notion or your own site. Update once and everywhere refreshes.',
+          },
+        ],
+      }}
+      comparison={{
+        heading: 'Virtual Bookshelf vs. a LinkedIn post vs. a Google Doc',
+        sub: 'How the common options stack up for sharing event resources.',
+        columns: [
+          { name: 'Virtual Bookshelf', highlight: true },
+          { name: 'LinkedIn post' },
+          { name: 'Google Doc / Notion' },
+        ],
+        rows: [
+          {
+            feature: 'Visual cards with thumbnails',
+            cells: [['Yes — automatic', true], ['No', false], ['No', false]],
+          },
+          {
+            feature: 'Shareable with one link',
+            cells: [['Yes', true], ['Yes (post URL)', true], ['Yes (doc URL)', true]],
+          },
+          {
+            feature: 'Works as a bio link',
+            cells: [['Yes', true], ['No', false], ['Poor UX', null]],
+          },
+          {
+            feature: 'Embeddable on any site',
+            cells: [['Yes', true], ['No', false], ['Limited', null]],
+          },
+          {
+            feature: 'Add personal notes per item',
+            cells: [['Yes', true], ['Only in caption', null], ['Yes', true]],
+          },
+          {
+            feature: 'Stays live and updatable',
+            cells: [['Yes', true], ['Buried in feed', false], ['Yes', true]],
+          },
+          {
+            feature: 'Free to use',
+            cells: [['Yes', true], ['Yes', true], ['Free + paid tiers', null]],
+          },
+        ],
+        note: 'Comparison reflects general platform capabilities as of June 2026.',
+      }}
+      steps={{
+        heading: 'Build your conference shelf in minutes',
+        sub: 'Most event recaps take less than ten minutes to shelve.',
+        items: [
+          {
+            n: 1,
+            title: 'Create a shelf',
+            body: 'Sign up free and name your shelf — "Engineering Leadership Live 2026" or whatever fits your event.',
+          },
+          {
+            n: 2,
+            title: 'Add talks and links',
+            body: 'Paste each recording, article, or speaker link. Thumbnails, titles, and descriptions fill in automatically.',
+          },
+          {
+            n: 3,
+            title: 'Share your URL',
+            body: 'Drop the shelf link in your LinkedIn post, newsletter, or bio. Embed it on your site if you want it live anywhere else.',
+          },
+        ],
+      }}
+      faq={{ heading: 'Frequently asked questions', items: FAQ }}
+      cta={{
+        heading: 'Shelve your next conference recap',
+        sub: 'Free to use. Looks great. Takes minutes. Your community will actually read it.',
+      }}
+      jsonLd={[
+        faqPageJsonLd(FAQ),
+        breadcrumbJsonLd([
+          { name: 'Home', url: baseUrl },
+          { name: 'Curate conference resources', url: `${baseUrl}/curate-conference-resources` },
+        ]),
+      ]}
+    />
+  );
+}

--- a/app/curate-conference-resources/page.tsx
+++ b/app/curate-conference-resources/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { CapabilityShowcase } from '@/components/home/CapabilityShowcase';
+import { LiveShelfExamples } from '@/components/landing/LiveShelfExamples';
 import { faqPageJsonLd, breadcrumbJsonLd, type FaqItem } from '@/lib/utils/landingSchema';
 
 const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.app';
@@ -122,23 +123,10 @@ export default function CurateConferenceResourcesPage() {
             <div className="text-center mb-8">
               <h2 id="example-heading" className={h2Class}>See what a conference shelf looks like</h2>
               <p className="mt-3 text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
-                This is a real shelf — live, browsable, and shareable with one link.
+                These are real shelves — live, browsable, and shareable with one link. Switch between events below.
               </p>
             </div>
-            <div className="rounded-2xl overflow-hidden border border-gray-200 dark:border-gray-800 shadow-lg bg-white dark:bg-gray-900">
-              <iframe
-                src={`${baseUrl}/embed/hnDScsft`}
-                title="Engineering Leadership Live — conference resource shelf example"
-                className="w-full"
-                style={{ height: '560px', border: 'none' }}
-                loading="lazy"
-              />
-            </div>
-            <p className="mt-4 text-center text-sm text-gray-500 dark:text-gray-400">
-              <Link href={`${baseUrl}/s/hnDScsft`} className="hover:underline" target="_blank" rel="noopener noreferrer">
-                Engineering Leadership Live SF — view the full shelf →
-              </Link>
-            </p>
+            <LiveShelfExamples />
           </section>
 
           {/* Before / after */}

--- a/app/curate-conference-resources/page.tsx
+++ b/app/curate-conference-resources/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
-import { AlternativeLandingPage } from '@/components/landing/AlternativeLandingPage';
+import Link from 'next/link';
+import { CapabilityShowcase } from '@/components/home/CapabilityShowcase';
 import { faqPageJsonLd, breadcrumbJsonLd, type FaqItem } from '@/lib/utils/landingSchema';
 
 const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.app';
@@ -54,110 +55,237 @@ const FAQ: FaqItem[] = [
   },
 ];
 
+const primaryCta =
+  'inline-block px-8 py-3.5 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg hover:bg-gray-800 dark:hover:bg-gray-200 transition-all font-medium text-lg shadow-md hover:shadow-lg';
+const h2Class = 'text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 tracking-tight';
+
+const jsonLd = [
+  faqPageJsonLd(FAQ),
+  breadcrumbJsonLd([
+    { name: 'Home', url: baseUrl },
+    { name: 'Curate conference resources', url: `${baseUrl}/curate-conference-resources` },
+  ]),
+];
+
 export default function CurateConferenceResourcesPage() {
   return (
-    <AlternativeLandingPage
-      breadcrumbLabel="Curate conference resources"
-      h1="Turn your conference recap into a shareable resource shelf"
-      heroSubhead="Stop sharing flat lists of links. Add your talks, recordings, and articles — cover art and titles fill in automatically — then share one beautiful URL with your community."
-      intro={{
-        heading: 'What is the best way to share conference resources?',
-        paragraphs: [
-          'After a great event, the instinct is to paste every link into a LinkedIn post or newsletter. The result is a wall of text that nobody saves and most people skip.',
-          'A Virtual Bookshelf shelf does the same thing visually — each talk or article becomes a rich card with a thumbnail, title, and your own note. Share one URL and your audience can browse, click, and bookmark what matters to them.',
-        ],
-      }}
-      reasons={{
-        heading: 'Built for the way people actually share event resources',
-        sub: 'Rich cards, automatic metadata, one link — everything a flat post is not.',
-        items: [
-          {
-            title: 'Visual cards, not a link dump',
-            body: 'Every recording, article, or speaker link becomes a card with a real thumbnail and title — far easier to scan than a bulleted list.',
-          },
-          {
-            title: 'Metadata fills in automatically',
-            body: 'Paste a YouTube link, a newsletter article, or a podcast episode URL and the title, thumbnail, and description populate themselves. No manual work.',
-          },
-          {
-            title: 'One link for everything',
-            body: 'Share a single URL in your post, bio, or email. Embed the live shelf in Notion or your own site. Update once and everywhere refreshes.',
-          },
-        ],
-      }}
-      comparison={{
-        heading: 'Virtual Bookshelf vs. a LinkedIn post vs. a Google Doc',
-        sub: 'How the common options stack up for sharing event resources.',
-        columns: [
-          { name: 'Virtual Bookshelf', highlight: true },
-          { name: 'LinkedIn post' },
-          { name: 'Google Doc / Notion' },
-        ],
-        rows: [
-          {
-            feature: 'Visual cards with thumbnails',
-            cells: [['Yes — automatic', true], ['No', false], ['No', false]],
-          },
-          {
-            feature: 'Shareable with one link',
-            cells: [['Yes', true], ['Yes (post URL)', true], ['Yes (doc URL)', true]],
-          },
-          {
-            feature: 'Works as a bio link',
-            cells: [['Yes', true], ['No', false], ['Poor UX', null]],
-          },
-          {
-            feature: 'Embeddable on any site',
-            cells: [['Yes', true], ['No', false], ['Limited', null]],
-          },
-          {
-            feature: 'Add personal notes per item',
-            cells: [['Yes', true], ['Only in caption', null], ['Yes', true]],
-          },
-          {
-            feature: 'Stays live and updatable',
-            cells: [['Yes', true], ['Buried in feed', false], ['Yes', true]],
-          },
-          {
-            feature: 'Free to use',
-            cells: [['Yes', true], ['Yes', true], ['Free + paid tiers', null]],
-          },
-        ],
-        note: 'Comparison reflects general platform capabilities as of June 2026.',
-      }}
-      steps={{
-        heading: 'Build your conference shelf in minutes',
-        sub: 'Most event recaps take less than ten minutes to shelve.',
-        items: [
-          {
-            n: 1,
-            title: 'Create a shelf',
-            body: 'Sign up free and name your shelf — "Engineering Leadership Live 2026" or whatever fits your event.',
-          },
-          {
-            n: 2,
-            title: 'Add talks and links',
-            body: 'Paste each recording, article, or speaker link. Thumbnails, titles, and descriptions fill in automatically.',
-          },
-          {
-            n: 3,
-            title: 'Share your URL',
-            body: 'Drop the shelf link in your LinkedIn post, newsletter, or bio. Embed it on your site if you want it live anywhere else.',
-          },
-        ],
-      }}
-      faq={{ heading: 'Frequently asked questions', items: FAQ }}
-      cta={{
-        heading: 'Shelve your next conference recap',
-        sub: 'Free to use. Looks great. Takes minutes. Your community will actually read it.',
-      }}
-      jsonLd={[
-        faqPageJsonLd(FAQ),
-        breadcrumbJsonLd([
-          { name: 'Home', url: baseUrl },
-          { name: 'Curate conference resources', url: `${baseUrl}/curate-conference-resources` },
-        ]),
-      ]}
-    />
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900 flex flex-col">
+      {jsonLd.map((schema, i) => (
+        <script key={i} type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }} />
+      ))}
+
+      <main id="main-content" className="flex-1">
+        {/* Hero */}
+        <section className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-12 sm:pt-20 pb-10 text-center">
+          <nav aria-label="Breadcrumb" className="mb-6">
+            <ol className="flex items-center justify-center gap-1.5 text-sm text-gray-500 dark:text-gray-400">
+              <li><Link href="/" className="hover:text-gray-700 dark:hover:text-gray-300">Home</Link></li>
+              <li aria-hidden="true">/</li>
+              <li className="text-gray-700 dark:text-gray-300 font-medium">Curate conference resources</li>
+            </ol>
+          </nav>
+
+          <h1 className="text-4xl sm:text-5xl font-bold text-gray-900 dark:text-gray-100 mb-4 tracking-tight">
+            Turn your conference recap into a shareable resource shelf
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400 text-lg sm:text-xl max-w-2xl mx-auto">
+            Stop sharing flat lists of links. Add your talks, recordings, and articles — cover art and titles fill in automatically — then share one beautiful URL with your community.
+          </p>
+
+          <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-3">
+            <Link href="/signup" className={primaryCta}>Create your shelf — free</Link>
+            <Link href="#live-example" className="inline-block px-8 py-3.5 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 font-medium text-lg">
+              See a live example
+            </Link>
+          </div>
+        </section>
+
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+
+          {/* AEO direct-answer intro */}
+          <section aria-labelledby="intro-heading" className="max-w-2xl mx-auto mb-20 sm:mb-24">
+            <h2 id="intro-heading" className={`${h2Class} mb-4`}>
+              What is the best way to share conference resources?
+            </h2>
+            <div className="space-y-4 text-gray-600 dark:text-gray-400 leading-relaxed">
+              <p>
+                After a great event, the instinct is to paste every link into a LinkedIn post or newsletter. The result is a wall of text that nobody saves and most people scroll past.
+              </p>
+              <p>
+                A Virtual Bookshelf shelf gives the same content a visual home — each talk or article becomes a rich card with a thumbnail, title, and your own note. Share one URL and your audience can browse, click, and bookmark what matters to them.
+              </p>
+            </div>
+          </section>
+
+          {/* Live example embed */}
+          <section id="live-example" aria-labelledby="example-heading" className="mb-20 sm:mb-28 scroll-mt-24">
+            <div className="text-center mb-8">
+              <h2 id="example-heading" className={h2Class}>See what a conference shelf looks like</h2>
+              <p className="mt-3 text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
+                This is a real shelf — live, browsable, and shareable with one link.
+              </p>
+            </div>
+            <div className="rounded-2xl overflow-hidden border border-gray-200 dark:border-gray-800 shadow-lg bg-white dark:bg-gray-900">
+              <iframe
+                src={`${baseUrl}/embed/hnDScsft`}
+                title="Engineering Leadership Live — conference resource shelf example"
+                className="w-full"
+                style={{ height: '560px', border: 'none' }}
+                loading="lazy"
+              />
+            </div>
+            <p className="mt-4 text-center text-sm text-gray-500 dark:text-gray-400">
+              <Link href={`${baseUrl}/s/hnDScsft`} className="hover:underline" target="_blank" rel="noopener noreferrer">
+                Engineering Leadership Live SF — view the full shelf →
+              </Link>
+            </p>
+          </section>
+
+          {/* Before / after */}
+          <section aria-labelledby="before-after-heading" className="mb-20 sm:mb-28">
+            <div className="text-center mb-10">
+              <h2 id="before-after-heading" className={h2Class}>From flat text to a living resource page</h2>
+              <p className="mt-3 text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
+                The same content — one format people save, one they scroll past.
+              </p>
+            </div>
+            <div className="grid gap-6 sm:grid-cols-2">
+              {/* Before */}
+              <div className="rounded-2xl border border-gray-200 dark:border-gray-800 bg-white/60 dark:bg-gray-900/50 p-6">
+                <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500 mb-4">Before — LinkedIn post</p>
+                <div className="space-y-2 text-sm text-gray-500 dark:text-gray-400 font-mono leading-relaxed">
+                  <p>🎤 Gregor Ojstersek — AI-Native Engineering Leadership</p>
+                  <p>Recording: lnkd.in/ej3qDUYZ</p>
+                  <p>Article: lnkd.in/eHS5JkYN</p>
+                  <p className="pt-1">🎤 Vinay Perneti — We Thought AI Transformation Was About Adopting Agents. We Were Wrong.</p>
+                  <p>Recording: lnkd.in/eMSUcBQj</p>
+                  <p>Article: lnkd.in/d9gMipvC</p>
+                  <p className="pt-1">🎤 Andrew Churchill — What Actually Works: AI Coding Patterns from the Top 1%...</p>
+                  <p>Recording: lnkd.in/eX4dVZ8y</p>
+                  <p className="text-gray-300 dark:text-gray-600">↓ buried in the feed after 24 hours</p>
+                </div>
+              </div>
+
+              {/* After */}
+              <div className="rounded-2xl border border-emerald-200 dark:border-emerald-900 bg-emerald-50/40 dark:bg-emerald-950/20 p-6">
+                <p className="text-xs font-semibold uppercase tracking-widest text-emerald-600 dark:text-emerald-400 mb-4">After — Virtual Bookshelf shelf</p>
+                <div className="space-y-3">
+                  {[
+                    { title: 'AI-Native Engineering Leadership', speaker: 'Gregor Ojstersek', color: 'bg-violet-100 dark:bg-violet-900/30' },
+                    { title: 'We Thought AI Transformation Was About Adopting Agents', speaker: 'Vinay Perneti', color: 'bg-blue-100 dark:bg-blue-900/30' },
+                    { title: 'What Actually Works: AI Coding Patterns from the Top 1%', speaker: 'Andrew Churchill', color: 'bg-amber-100 dark:bg-amber-900/30' },
+                  ].map((item) => (
+                    <div key={item.title} className={`flex items-center gap-3 rounded-xl ${item.color} p-3`}>
+                      <div className="w-10 h-10 rounded-lg bg-gray-200 dark:bg-gray-700 shrink-0 flex items-center justify-center">
+                        <svg className="w-5 h-5 text-gray-400" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                          <path d="M8 5v14l11-7z" />
+                        </svg>
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-xs font-semibold text-gray-900 dark:text-gray-100 truncate">{item.title}</p>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">{item.speaker}</p>
+                      </div>
+                    </div>
+                  ))}
+                  <p className="text-xs text-emerald-600 dark:text-emerald-400 pt-1 font-medium">✓ Lives at one URL forever · auto-fills thumbnails · embeddable</p>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          {/* Capability showcase */}
+          <CapabilityShowcase />
+
+          {/* Why / 3 reasons */}
+          <section aria-labelledby="reasons-heading" className="mb-20 sm:mb-28">
+            <div className="text-center mb-10">
+              <h2 id="reasons-heading" className={h2Class}>Built for the way people actually share event resources</h2>
+              <p className="mt-3 text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
+                Rich cards, automatic metadata, one link — everything a flat post is not.
+              </p>
+            </div>
+            <ul className="grid gap-6 sm:grid-cols-3">
+              {[
+                {
+                  title: 'Visual cards, not a link dump',
+                  body: 'Every recording, article, or speaker link becomes a card with a real thumbnail and title — far easier to scan than a bulleted list.',
+                },
+                {
+                  title: 'Metadata fills in automatically',
+                  body: 'Paste a YouTube link, a newsletter article, or a podcast episode URL and the title, thumbnail, and description populate themselves. No manual work.',
+                },
+                {
+                  title: 'One link for everything',
+                  body: 'Share a single URL in your post, bio, or email. Embed the live shelf in Notion or your own site. Update once and everywhere refreshes.',
+                },
+              ].map((r) => (
+                <li key={r.title} className="rounded-2xl border border-gray-200 dark:border-gray-800 bg-white/60 dark:bg-gray-900/50 p-6">
+                  <h3 className="font-semibold text-gray-900 dark:text-gray-100">{r.title}</h3>
+                  <p className="mt-2 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">{r.body}</p>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          {/* Steps */}
+          <section aria-labelledby="steps-heading" className="mb-20 sm:mb-28">
+            <div className="text-center mb-10">
+              <h2 id="steps-heading" className={h2Class}>Build your conference shelf in minutes</h2>
+              <p className="mt-3 text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">Most event recaps take less than ten minutes to shelve.</p>
+            </div>
+            <ol className="grid gap-6 sm:grid-cols-3">
+              {[
+                { n: 1, title: 'Create a shelf', body: 'Sign up free and name your shelf — "Engineering Leadership Live 2026" or whatever fits your event.' },
+                { n: 2, title: 'Add talks and links', body: 'Paste each recording, article, or speaker link. Thumbnails, titles, and descriptions fill in automatically.' },
+                { n: 3, title: 'Share your URL', body: 'Drop the shelf link in your LinkedIn post, newsletter, or bio. Embed it on your site if you want it live anywhere else.' },
+              ].map((step) => (
+                <li key={step.n} className="text-center">
+                  <span className="mx-auto grid place-items-center w-10 h-10 rounded-full bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 font-semibold">{step.n}</span>
+                  <h3 className="mt-4 font-semibold text-gray-900 dark:text-gray-100">{step.title}</h3>
+                  <p className="mt-1 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">{step.body}</p>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          {/* FAQ */}
+          <section aria-labelledby="faq-heading" className="max-w-2xl mx-auto mb-20 sm:mb-28">
+            <h2 id="faq-heading" className={`${h2Class} text-center mb-10`}>Frequently asked questions</h2>
+            <dl className="space-y-8">
+              {FAQ.map((item) => (
+                <div key={item.q}>
+                  <dt className="font-semibold text-gray-900 dark:text-gray-100 text-base sm:text-lg">{item.q}</dt>
+                  <dd className="mt-2 text-gray-600 dark:text-gray-400 leading-relaxed">{item.a}</dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+
+          {/* Final CTA */}
+          <section className="text-center pb-20 sm:pb-28">
+            <h2 className={h2Class}>Shelve your next conference recap</h2>
+            <p className="mt-3 text-gray-600 dark:text-gray-400 max-w-xl mx-auto">
+              Free to use. Looks great. Takes minutes. Your community will actually read it.
+            </p>
+            <div className="mt-7">
+              <Link href="/signup" className={primaryCta}>Create your shelf — free</Link>
+              <p className="mt-5 text-sm text-gray-600 dark:text-gray-400">
+                Already have an account?{' '}
+                <Link href="/login" className="text-gray-900 dark:text-gray-100 hover:underline font-medium">Sign in</Link>
+              </p>
+            </div>
+          </section>
+        </div>
+      </main>
+
+      <footer className="border-t border-gray-200 dark:border-gray-800 bg-white/50 dark:bg-gray-900/50">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+          <div className="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-gray-500 dark:text-gray-400">
+            <p>© {new Date().getFullYear()} Virtual Bookshelf</p>
+            <Link href="/" className="hover:text-gray-700 dark:hover:text-gray-300 transition-colors font-medium">Back to home</Link>
+          </div>
+        </div>
+      </footer>
+    </div>
   );
 }

--- a/app/curate-conference-resources/page.tsx
+++ b/app/curate-conference-resources/page.tsx
@@ -155,28 +155,18 @@ export default function CurateConferenceResourcesPage() {
               </div>
 
               {/* After */}
-              <div className="rounded-2xl border border-emerald-200 dark:border-emerald-900 bg-emerald-50/40 dark:bg-emerald-950/20 p-6">
+              <div className="rounded-2xl border border-emerald-200 dark:border-emerald-900 bg-emerald-50/40 dark:bg-emerald-950/20 p-6 flex flex-col">
                 <p className="text-xs font-semibold uppercase tracking-widest text-emerald-600 dark:text-emerald-400 mb-4">After — Virtual Bookshelf shelf</p>
-                <div className="space-y-3">
-                  {[
-                    { title: 'AI-Native Engineering Leadership', speaker: 'Gregor Ojstersek', color: 'bg-violet-100 dark:bg-violet-900/30' },
-                    { title: 'We Thought AI Transformation Was About Adopting Agents', speaker: 'Vinay Perneti', color: 'bg-blue-100 dark:bg-blue-900/30' },
-                    { title: 'What Actually Works: AI Coding Patterns from the Top 1%', speaker: 'Andrew Churchill', color: 'bg-amber-100 dark:bg-amber-900/30' },
-                  ].map((item) => (
-                    <div key={item.title} className={`flex items-center gap-3 rounded-xl ${item.color} p-3`}>
-                      <div className="w-10 h-10 rounded-lg bg-gray-200 dark:bg-gray-700 shrink-0 flex items-center justify-center">
-                        <svg className="w-5 h-5 text-gray-400" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                          <path d="M8 5v14l11-7z" />
-                        </svg>
-                      </div>
-                      <div className="min-w-0">
-                        <p className="text-xs font-semibold text-gray-900 dark:text-gray-100 truncate">{item.title}</p>
-                        <p className="text-xs text-gray-500 dark:text-gray-400">{item.speaker}</p>
-                      </div>
-                    </div>
-                  ))}
-                  <p className="text-xs text-emerald-600 dark:text-emerald-400 pt-1 font-medium">✓ Lives at one URL forever · auto-fills thumbnails · embeddable</p>
+                <div className="rounded-xl overflow-hidden border border-emerald-200/60 dark:border-emerald-900/60 bg-white dark:bg-gray-900">
+                  <iframe
+                    src={`${baseUrl}/embed/hnDScsft`}
+                    title="Engineering Leadership Live — real embedded shelf"
+                    className="w-full"
+                    style={{ height: '360px', border: 'none' }}
+                    loading="lazy"
+                  />
                 </div>
+                <p className="text-xs text-emerald-600 dark:text-emerald-400 pt-3 font-medium">✓ This is a real, live shelf — not a mockup. Lives at one URL, auto-fills thumbnails, embeddable.</p>
               </div>
             </div>
           </section>

--- a/app/embed-anywhere/page.tsx
+++ b/app/embed-anywhere/page.tsx
@@ -1,0 +1,219 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { EmbedContextSwitcher } from '@/components/landing/EmbedContextSwitcher';
+import { faqPageJsonLd, breadcrumbJsonLd, type FaqItem } from '@/lib/utils/landingSchema';
+
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.app';
+
+export const metadata: Metadata = {
+  title: 'Embed a Shelf in Your Newsletter, Email, or Website — Virtual Bookshelf',
+  description:
+    'Embed a live, clickable resource shelf directly in a newsletter, email, or website. One snippet, always up to date — no screenshots, no broken link lists.',
+  alternates: { canonical: '/embed-anywhere' },
+  openGraph: {
+    title: 'Embed a Shelf Anywhere — Newsletter, Email, or Website',
+    description:
+      'Drop a live, clickable resource shelf into a newsletter, email, or website with one embed snippet. Update the shelf once and it updates everywhere it is embedded.',
+    type: 'website',
+    url: `${baseUrl}/embed-anywhere`,
+    siteName: 'Virtual Bookshelf',
+    images: [{ url: `${baseUrl}/api/og/landing`, width: 1200, height: 630, alt: 'Virtual Bookshelf — embed a shelf anywhere' }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Embed a Shelf Anywhere — Newsletter, Email, or Website',
+    description: 'Drop a live, clickable resource shelf into a newsletter, email, or website with one embed snippet.',
+    images: [`${baseUrl}/api/og/landing`],
+  },
+};
+
+const FAQ: FaqItem[] = [
+  {
+    q: 'Can I embed a curated link list in a newsletter?',
+    a: 'Yes. Most newsletter tools (Substack, ConvertKit, beehiiv, Mailchimp) support an HTML or iframe embed block. Paste your shelf\'s embed snippet into that block and the shelf renders live inside the newsletter, with every card clickable.',
+  },
+  {
+    q: 'Does the embed work inside an email?',
+    a: 'Many email clients strip iframes for security, so for email we recommend either linking to the shelf with a styled preview image, or using the embed inside email-builder tools that support live web content blocks. For guaranteed rendering in any inbox, share the shelf link directly — the Open Graph preview already looks like a rich card.',
+  },
+  {
+    q: 'How do I embed a resource shelf on my website?',
+    a: 'Copy the embed snippet from your shelf\'s share settings and paste it into any page that accepts HTML — a blog post, a resources page, a Webflow embed block, or a custom site. It renders as a live iframe and stays in sync with the shelf.',
+  },
+  {
+    q: 'Does the embedded shelf update automatically?',
+    a: 'Yes. The embed always reflects the current state of the shelf. Add, remove, or reorder items once, and every place you have embedded that shelf — newsletter archive, website, docs page — shows the update without re-pasting anything.',
+  },
+  {
+    q: 'Can I customize the look of an embedded shelf?',
+    a: 'Yes. The embed supports a light or dark theme and a custom accent color so it can match your newsletter or site branding instead of looking like an inserted widget.',
+  },
+  {
+    q: 'Is embedding a shelf free?',
+    a: 'Yes, embedding is included free with any Virtual Bookshelf shelf. Create a shelf, add your items, and copy the embed snippet from the share menu.',
+  },
+];
+
+const primaryCta =
+  'inline-block px-8 py-3.5 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg hover:bg-gray-800 dark:hover:bg-gray-200 transition-all font-medium text-lg shadow-md hover:shadow-lg';
+const h2Class = 'text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 tracking-tight';
+
+const jsonLd = [
+  faqPageJsonLd(FAQ),
+  breadcrumbJsonLd([
+    { name: 'Home', url: baseUrl },
+    { name: 'Embed anywhere', url: `${baseUrl}/embed-anywhere` },
+  ]),
+];
+
+export default function EmbedAnywherePage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900 flex flex-col">
+      {jsonLd.map((schema, i) => (
+        <script key={i} type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }} />
+      ))}
+
+      <main id="main-content" className="flex-1">
+        {/* Hero */}
+        <section className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-12 sm:pt-20 pb-10 text-center">
+          <nav aria-label="Breadcrumb" className="mb-6">
+            <ol className="flex items-center justify-center gap-1.5 text-sm text-gray-500 dark:text-gray-400">
+              <li><Link href="/" className="hover:text-gray-700 dark:hover:text-gray-300">Home</Link></li>
+              <li aria-hidden="true">/</li>
+              <li className="text-gray-700 dark:text-gray-300 font-medium">Embed anywhere</li>
+            </ol>
+          </nav>
+
+          <h1 className="text-4xl sm:text-5xl font-bold text-gray-900 dark:text-gray-100 mb-4 tracking-tight">
+            Embed a live shelf in your newsletter, email, or website
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400 text-lg sm:text-xl max-w-2xl mx-auto">
+            One snippet. A real, clickable resource shelf wherever you paste it — always up to date, no screenshots, no broken lists.
+          </p>
+
+          <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-3">
+            <Link href="/signup" className={primaryCta}>Create your shelf — free</Link>
+            <Link href="#try-it" className="inline-block px-8 py-3.5 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 font-medium text-lg">
+              Try it below
+            </Link>
+          </div>
+        </section>
+
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+
+          {/* AEO direct-answer intro */}
+          <section aria-labelledby="intro-heading" className="max-w-2xl mx-auto mb-16 sm:mb-20">
+            <h2 id="intro-heading" className={`${h2Class} mb-4`}>
+              Where can you embed a Virtual Bookshelf shelf?
+            </h2>
+            <div className="space-y-4 text-gray-600 dark:text-gray-400 leading-relaxed">
+              <p>
+                Anywhere that accepts HTML or an iframe: a newsletter platform like Substack or beehiiv, a website or blog post, a Notion or Webflow page, or your own docs site. Paste one snippet and the shelf renders live — clickable cards, real thumbnails, no manual upkeep.
+              </p>
+            </div>
+          </section>
+
+          {/* Interactive demo */}
+          <section id="try-it" aria-labelledby="try-it-heading" className="mb-20 sm:mb-28 scroll-mt-24">
+            <div className="text-center mb-8">
+              <h2 id="try-it-heading" className={h2Class}>See it embedded in three places</h2>
+              <p className="mt-3 text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
+                Same shelf, same snippet — switch the tab to see how it looks dropped into each context. The cards are live and clickable.
+              </p>
+            </div>
+            <EmbedContextSwitcher />
+          </section>
+
+          {/* Why */}
+          <section aria-labelledby="reasons-heading" className="mb-20 sm:mb-28">
+            <div className="text-center mb-10">
+              <h2 id="reasons-heading" className={h2Class}>Why embed instead of screenshot or link</h2>
+              <p className="mt-3 text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
+                A screenshot goes stale the moment you update your list. An embed never does.
+              </p>
+            </div>
+            <ul className="grid gap-6 sm:grid-cols-3">
+              {[
+                {
+                  title: 'Always current',
+                  body: 'Update the shelf once and every embed — newsletter archive, website, docs — reflects the change automatically.',
+                },
+                {
+                  title: 'Actually clickable',
+                  body: 'Unlike a screenshot, every card in the embed links straight to the recording, article, or product. No dead pixels.',
+                },
+                {
+                  title: 'Matches your brand',
+                  body: 'Choose light or dark theme and a custom accent color so the embed looks native to where you place it.',
+                },
+              ].map((r) => (
+                <li key={r.title} className="rounded-2xl border border-gray-200 dark:border-gray-800 bg-white/60 dark:bg-gray-900/50 p-6">
+                  <h3 className="font-semibold text-gray-900 dark:text-gray-100">{r.title}</h3>
+                  <p className="mt-2 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">{r.body}</p>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          {/* Steps */}
+          <section aria-labelledby="steps-heading" className="mb-20 sm:mb-28">
+            <div className="text-center mb-10">
+              <h2 id="steps-heading" className={h2Class}>Get your embed snippet in three steps</h2>
+              <p className="mt-3 text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">No code required.</p>
+            </div>
+            <ol className="grid gap-6 sm:grid-cols-3">
+              {[
+                { n: 1, title: 'Build your shelf', body: 'Add the books, podcasts, talks, or links you want to share. Cover art and titles fill in automatically.' },
+                { n: 2, title: 'Open share settings', body: 'Copy the embed snippet from your shelf — choose a theme and accent color if you want it to match your brand.' },
+                { n: 3, title: 'Paste it anywhere', body: 'Drop the snippet into your newsletter platform, website, or docs page. It renders live immediately.' },
+              ].map((step) => (
+                <li key={step.n} className="text-center">
+                  <span className="mx-auto grid place-items-center w-10 h-10 rounded-full bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 font-semibold">{step.n}</span>
+                  <h3 className="mt-4 font-semibold text-gray-900 dark:text-gray-100">{step.title}</h3>
+                  <p className="mt-1 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">{step.body}</p>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          {/* FAQ */}
+          <section aria-labelledby="faq-heading" className="max-w-2xl mx-auto mb-20 sm:mb-28">
+            <h2 id="faq-heading" className={`${h2Class} text-center mb-10`}>Frequently asked questions</h2>
+            <dl className="space-y-8">
+              {FAQ.map((item) => (
+                <div key={item.q}>
+                  <dt className="font-semibold text-gray-900 dark:text-gray-100 text-base sm:text-lg">{item.q}</dt>
+                  <dd className="mt-2 text-gray-600 dark:text-gray-400 leading-relaxed">{item.a}</dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+
+          {/* Final CTA */}
+          <section className="text-center pb-20 sm:pb-28">
+            <h2 className={h2Class}>Embed your first shelf today</h2>
+            <p className="mt-3 text-gray-600 dark:text-gray-400 max-w-xl mx-auto">
+              Free to use. No code. Updates everywhere automatically.
+            </p>
+            <div className="mt-7">
+              <Link href="/signup" className={primaryCta}>Create your shelf — free</Link>
+              <p className="mt-5 text-sm text-gray-600 dark:text-gray-400">
+                Already have an account?{' '}
+                <Link href="/login" className="text-gray-900 dark:text-gray-100 hover:underline font-medium">Sign in</Link>
+              </p>
+            </div>
+          </section>
+        </div>
+      </main>
+
+      <footer className="border-t border-gray-200 dark:border-gray-800 bg-white/50 dark:bg-gray-900/50">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+          <div className="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-gray-500 dark:text-gray-400">
+            <p>© {new Date().getFullYear()} Virtual Bookshelf</p>
+            <Link href="/" className="hover:text-gray-700 dark:hover:text-gray-300 transition-colors font-medium">Back to home</Link>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -22,6 +22,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${baseUrl}/login`, changeFrequency: 'yearly', priority: 0.3 },
     { url: `${baseUrl}/signup`, changeFrequency: 'yearly', priority: 0.3 },
     { url: `${baseUrl}/curate-conference-resources`, changeFrequency: 'monthly', priority: 0.9 },
+    { url: `${baseUrl}/embed-anywhere`, changeFrequency: 'monthly', priority: 0.9 },
     ...shelfUrls,
   ]
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -21,6 +21,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${baseUrl}/goodreads-alternative`, changeFrequency: 'monthly', priority: 0.9 },
     { url: `${baseUrl}/login`, changeFrequency: 'yearly', priority: 0.3 },
     { url: `${baseUrl}/signup`, changeFrequency: 'yearly', priority: 0.3 },
+    { url: `${baseUrl}/curate-conference-resources`, changeFrequency: 'monthly', priority: 0.9 },
     ...shelfUrls,
   ]
 }

--- a/components/landing/EmbedContextSwitcher.tsx
+++ b/components/landing/EmbedContextSwitcher.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState } from 'react';
+
+interface EmbedContext {
+  id: string;
+  label: string;
+}
+
+const CONTEXTS: EmbedContext[] = [
+  { id: 'newsletter', label: 'Newsletter' },
+  { id: 'email', label: 'Email' },
+  { id: 'website', label: 'Website' },
+];
+
+const EMBED_SRC = 'https://virtualbookshelf.app/embed/hnDScsft?theme=light';
+
+function EmbedFrame({ height }: { height: number }) {
+  return (
+    <iframe
+      src={EMBED_SRC}
+      title="Engineering Leadership Live — embedded resource shelf"
+      className="w-full rounded-lg"
+      style={{ height, border: 'none' }}
+      loading="lazy"
+    />
+  );
+}
+
+function NewsletterMock() {
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-800 shadow-lg overflow-hidden">
+      <div className="px-6 sm:px-10 py-6 border-b border-gray-100 dark:border-gray-800">
+        <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">The Weekly Dispatch</p>
+        <h3 className="mt-1 text-xl font-bold text-gray-900 dark:text-gray-100">Issue #42 — This week in engineering leadership</h3>
+      </div>
+      <div className="px-6 sm:px-10 py-8 space-y-5">
+        <p className="text-gray-600 dark:text-gray-400 leading-relaxed">
+          Hey everyone — I caught a few talks from Engineering Leadership LIVE in San Francisco this week, and they were too good not to share. Recordings and articles below 👇
+        </p>
+        <div className="rounded-xl border border-gray-200 dark:border-gray-800 p-2 bg-gray-50 dark:bg-gray-950">
+          <EmbedFrame height={460} />
+        </div>
+        <p className="text-gray-600 dark:text-gray-400 leading-relaxed">
+          Click through any of the cards above — they open straight to the recording or article. See you next week.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function EmailMock() {
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-800 shadow-lg overflow-hidden">
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-950">
+        <span className="w-3 h-3 rounded-full bg-red-400" />
+        <span className="w-3 h-3 rounded-full bg-yellow-400" />
+        <span className="w-3 h-3 rounded-full bg-green-400" />
+        <span className="ml-3 text-xs text-gray-400 dark:text-gray-500">Inbox — Conference recap from Sarah</span>
+      </div>
+      <div className="px-6 sm:px-10 py-6 border-b border-gray-100 dark:border-gray-800">
+        <p className="text-sm text-gray-500 dark:text-gray-400">From: Sarah Chen &lt;sarah@company.com&gt;</p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">Subject: Talks worth your time from last week's event</p>
+      </div>
+      <div className="px-6 sm:px-10 py-8 space-y-5">
+        <p className="text-gray-600 dark:text-gray-400 leading-relaxed">Hi team,</p>
+        <p className="text-gray-600 dark:text-gray-400 leading-relaxed">
+          I went to Engineering Leadership LIVE and pulled together the talks I think are most relevant to what we're working on. Everything's linked below — just click through.
+        </p>
+        <div className="rounded-xl border border-gray-200 dark:border-gray-800 p-2 bg-gray-50 dark:bg-gray-950">
+          <EmbedFrame height={460} />
+        </div>
+        <p className="text-gray-600 dark:text-gray-400 leading-relaxed">Best,<br />Sarah</p>
+      </div>
+    </div>
+  );
+}
+
+function WebsiteMock() {
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-800 shadow-lg overflow-hidden">
+      <div className="flex items-center justify-between px-6 sm:px-10 py-4 border-b border-gray-100 dark:border-gray-800">
+        <span className="font-bold text-gray-900 dark:text-gray-100">Acme Conf</span>
+        <div className="hidden sm:flex gap-6 text-sm text-gray-500 dark:text-gray-400">
+          <span>Schedule</span>
+          <span>Speakers</span>
+          <span className="text-gray-900 dark:text-gray-100 font-medium">Resources</span>
+        </div>
+      </div>
+      <div className="px-6 sm:px-10 py-8 space-y-5">
+        <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100">Talk recordings & resources</h3>
+        <p className="text-gray-600 dark:text-gray-400 leading-relaxed">
+          Missed a session, or want to revisit one? All recordings and speaker resources from this year's event are below.
+        </p>
+        <div className="rounded-xl border border-gray-200 dark:border-gray-800 p-2 bg-gray-50 dark:bg-gray-950">
+          <EmbedFrame height={460} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function EmbedContextSwitcher() {
+  const [active, setActive] = useState('newsletter');
+
+  return (
+    <div>
+      <div role="tablist" aria-label="Embed context" className="flex justify-center gap-2 mb-8">
+        {CONTEXTS.map((ctx) => (
+          <button
+            key={ctx.id}
+            role="tab"
+            aria-selected={active === ctx.id}
+            onClick={() => setActive(ctx.id)}
+            className={`px-5 py-2.5 rounded-full text-sm font-medium transition-colors ${
+              active === ctx.id
+                ? 'bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900'
+                : 'bg-white dark:bg-gray-900 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-800 hover:border-gray-300 dark:hover:border-gray-700'
+            }`}
+          >
+            {ctx.label}
+          </button>
+        ))}
+      </div>
+
+      {active === 'newsletter' && <NewsletterMock />}
+      {active === 'email' && <EmailMock />}
+      {active === 'website' && <WebsiteMock />}
+    </div>
+  );
+}

--- a/components/landing/EmbedContextSwitcher.tsx
+++ b/components/landing/EmbedContextSwitcher.tsx
@@ -13,13 +13,15 @@ const CONTEXTS: EmbedContext[] = [
   { id: 'website', label: 'Website' },
 ];
 
-const EMBED_SRC = 'https://virtualbookshelf.app/embed/hnDScsft?theme=light';
+const NEWSLETTER_SRC = 'https://virtualbookshelf.app/embed/hnDScsft?theme=light';
+const EMAIL_SRC = 'https://virtualbookshelf.app/embed/bzU3ZvNo?theme=light';
+const WEBSITE_SRC = 'https://virtualbookshelf.app/embed/y6b67aoh?theme=light';
 
-function EmbedFrame({ height }: { height: number }) {
+function EmbedFrame({ src, title, height }: { src: string; title: string; height: number }) {
   return (
     <iframe
-      src={EMBED_SRC}
-      title="Engineering Leadership Live — embedded resource shelf"
+      src={src}
+      title={title}
       className="w-full rounded-lg"
       style={{ height, border: 'none' }}
       loading="lazy"
@@ -39,7 +41,7 @@ function NewsletterMock() {
           Hey everyone — I caught a few talks from Engineering Leadership LIVE in San Francisco this week, and they were too good not to share. Recordings and articles below 👇
         </p>
         <div className="rounded-xl border border-gray-200 dark:border-gray-800 p-2 bg-gray-50 dark:bg-gray-950">
-          <EmbedFrame height={460} />
+          <EmbedFrame src={NEWSLETTER_SRC} title="Engineering Leadership Live — embedded resource shelf" height={460} />
         </div>
         <p className="text-gray-600 dark:text-gray-400 leading-relaxed">
           Click through any of the cards above — they open straight to the recording or article. See you next week.
@@ -56,19 +58,19 @@ function EmailMock() {
         <span className="w-3 h-3 rounded-full bg-red-400" />
         <span className="w-3 h-3 rounded-full bg-yellow-400" />
         <span className="w-3 h-3 rounded-full bg-green-400" />
-        <span className="ml-3 text-xs text-gray-400 dark:text-gray-500">Inbox — Conference recap from Sarah</span>
+        <span className="ml-3 text-xs text-gray-400 dark:text-gray-500">Inbox — Design talks worth your time</span>
       </div>
       <div className="px-6 sm:px-10 py-6 border-b border-gray-100 dark:border-gray-800">
         <p className="text-sm text-gray-500 dark:text-gray-400">From: Sarah Chen &lt;sarah@company.com&gt;</p>
-        <p className="text-sm text-gray-500 dark:text-gray-400">Subject: Talks worth your time from last week's event</p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">Subject: Config 2025 — the sessions worth your time</p>
       </div>
       <div className="px-6 sm:px-10 py-8 space-y-5">
         <p className="text-gray-600 dark:text-gray-400 leading-relaxed">Hi team,</p>
         <p className="text-gray-600 dark:text-gray-400 leading-relaxed">
-          I went to Engineering Leadership LIVE and pulled together the talks I think are most relevant to what we're working on. Everything's linked below — just click through.
+          I pulled together the Config 2025 sessions I think are most relevant to what we're building. Everything's linked below — just click through.
         </p>
         <div className="rounded-xl border border-gray-200 dark:border-gray-800 p-2 bg-gray-50 dark:bg-gray-950">
-          <EmbedFrame height={460} />
+          <EmbedFrame src={EMAIL_SRC} title="Config 2025 — embedded resource shelf" height={460} />
         </div>
         <p className="text-gray-600 dark:text-gray-400 leading-relaxed">Best,<br />Sarah</p>
       </div>
@@ -80,7 +82,7 @@ function WebsiteMock() {
   return (
     <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-800 shadow-lg overflow-hidden">
       <div className="flex items-center justify-between px-6 sm:px-10 py-4 border-b border-gray-100 dark:border-gray-800">
-        <span className="font-bold text-gray-900 dark:text-gray-100">Acme Conf</span>
+        <span className="font-bold text-gray-900 dark:text-gray-100">Data + AI Summit</span>
         <div className="hidden sm:flex gap-6 text-sm text-gray-500 dark:text-gray-400">
           <span>Schedule</span>
           <span>Speakers</span>
@@ -88,12 +90,12 @@ function WebsiteMock() {
         </div>
       </div>
       <div className="px-6 sm:px-10 py-8 space-y-5">
-        <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100">Talk recordings & resources</h3>
+        <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100">Keynote recordings & resources</h3>
         <p className="text-gray-600 dark:text-gray-400 leading-relaxed">
-          Missed a session, or want to revisit one? All recordings and speaker resources from this year's event are below.
+          Missed a session, or want to revisit one? All keynote recordings and resources from this year's summit are below.
         </p>
         <div className="rounded-xl border border-gray-200 dark:border-gray-800 p-2 bg-gray-50 dark:bg-gray-950">
-          <EmbedFrame height={460} />
+          <EmbedFrame src={WEBSITE_SRC} title="Data + AI Summit 2025 — embedded resource shelf" height={460} />
         </div>
       </div>
     </div>

--- a/components/landing/EmbedContextSwitcher.tsx
+++ b/components/landing/EmbedContextSwitcher.tsx
@@ -67,7 +67,7 @@ function EmailMock() {
       <div className="px-6 sm:px-10 py-8 space-y-5">
         <p className="text-gray-600 dark:text-gray-400 leading-relaxed">Hi team,</p>
         <p className="text-gray-600 dark:text-gray-400 leading-relaxed">
-          I pulled together the Config 2025 sessions I think are most relevant to what we're building. Everything's linked below — just click through.
+          I pulled together the Config 2025 sessions I think are most relevant to what we&apos;re building. Everything&apos;s linked below — just click through.
         </p>
         <div className="rounded-xl border border-gray-200 dark:border-gray-800 p-2 bg-gray-50 dark:bg-gray-950">
           <EmbedFrame src={EMAIL_SRC} title="Config 2025 — embedded resource shelf" height={460} />
@@ -92,7 +92,7 @@ function WebsiteMock() {
       <div className="px-6 sm:px-10 py-8 space-y-5">
         <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100">Keynote recordings & resources</h3>
         <p className="text-gray-600 dark:text-gray-400 leading-relaxed">
-          Missed a session, or want to revisit one? All keynote recordings and resources from this year's summit are below.
+          Missed a session, or want to revisit one? All keynote recordings and resources from this year&apos;s summit are below.
         </p>
         <div className="rounded-xl border border-gray-200 dark:border-gray-800 p-2 bg-gray-50 dark:bg-gray-950">
           <EmbedFrame src={WEBSITE_SRC} title="Data + AI Summit 2025 — embedded resource shelf" height={460} />

--- a/components/landing/LiveShelfExamples.tsx
+++ b/components/landing/LiveShelfExamples.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Example {
+  id: string;
+  label: string;
+  shareToken: string;
+  title: string;
+}
+
+const EXAMPLES: Example[] = [
+  { id: 'eng-leadership', label: 'Engineering Leadership LIVE', shareToken: 'hnDScsft', title: 'Engineering Leadership Live SF' },
+  { id: 'config', label: 'Config 2025 (Figma)', shareToken: 'bzU3ZvNo', title: 'Config 2025' },
+  { id: 'data-ai', label: 'Data + AI Summit', shareToken: 'y6b67aoh', title: 'Databricks Data + AI Summit 2025' },
+];
+
+export function LiveShelfExamples() {
+  const [active, setActive] = useState(EXAMPLES[0].id);
+  const current = EXAMPLES.find((e) => e.id === active) ?? EXAMPLES[0];
+
+  return (
+    <div>
+      <div role="tablist" aria-label="Example conference shelf" className="flex flex-wrap justify-center gap-2 mb-8">
+        {EXAMPLES.map((ex) => (
+          <button
+            key={ex.id}
+            role="tab"
+            aria-selected={active === ex.id}
+            onClick={() => setActive(ex.id)}
+            className={`px-5 py-2.5 rounded-full text-sm font-medium transition-colors ${
+              active === ex.id
+                ? 'bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900'
+                : 'bg-white dark:bg-gray-900 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-800 hover:border-gray-300 dark:hover:border-gray-700'
+            }`}
+          >
+            {ex.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="rounded-2xl overflow-hidden border border-gray-200 dark:border-gray-800 shadow-lg bg-white dark:bg-gray-900">
+        <iframe
+          key={current.shareToken}
+          src={`https://virtualbookshelf.app/embed/${current.shareToken}`}
+          title={`${current.title} — conference resource shelf example`}
+          className="w-full"
+          style={{ height: '560px', border: 'none' }}
+          loading="lazy"
+        />
+      </div>
+      <p className="mt-4 text-center text-sm text-gray-500 dark:text-gray-400">
+        <a
+          href={`https://virtualbookshelf.app/s/${current.shareToken}`}
+          className="hover:underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {current.title} — view the full shelf →
+        </a>
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds two new SEO/AEO-targeted landing pages and supporting components, continuing the [alternative-landing-pages](https://github.com/arielwernick/virtual_bookshelf) pattern with real (not fabricated) live shelf examples throughout.

- **`/curate-conference-resources`** — targets queries like "how to share conference resources," "organize event talks and links." Includes an AEO direct-answer intro, a tabbed live-example section (`LiveShelfExamples`) cycling through three real shelves (Engineering Leadership LIVE, Config 2025, Databricks Data + AI Summit 2025), a before/after comparison (flat LinkedIn text vs. an actual embedded shelf — not a mockup), capability showcase, steps, and an FAQ with `FAQPage` + `BreadcrumbList` JSON-LD.
- **`/embed-anywhere`** — targets embed-related queries ("embed a curated list in a newsletter," "embed resource list on website"). Includes an interactive `EmbedContextSwitcher` with three tabs (Newsletter, Email, Website), each a realistic mockup chrome (masthead, inbox header, site nav) wrapping a real, clickable embed of a different shelf.
- Ported/added shared landing infra needed since this worktree was behind `main`: `components/landing/AlternativeLandingPage.tsx`, `ComparisonTable.tsx`, `lib/utils/landingSchema.ts` (FAQPage/BreadcrumbList JSON-LD builders).
- Both new routes added to `app/sitemap.ts` at priority 0.9.

## Why

Part of the ongoing SEO/AEO traffic initiative — these pages target long-tail, high-intent queries from people who already curate content (conference recaps, newsletters) and want a better way to share it than a flat LinkedIn post, plus people specifically looking to embed a resource list somewhere.

All "live example" sections use genuine shelves (`hnDScsft`, `bzU3ZvNo`, `y6b67aoh`) rather than hardcoded mock data, including an earlier before/after section that was initially built with fabricated cards and was corrected to embed a real shelf instead.

## Test plan

- [x] `npx tsc --noEmit` — no errors introduced by new files
- [x] Verified `/curate-conference-resources` in browser preview: live example tabs switch correctly between all three real shelves, before/after section renders the real embed
- [x] Verified `/embed-anywhere` in browser preview: all three context tabs (Newsletter/Email/Website) load distinct real shelf embeds, confirmed via `iframe.src` per tab
- [ ] Confirm both pages render correctly in production once deployed (shelf embeds point at `virtualbookshelf.app`, not relative paths, so they'll work pre-merge too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)