### PR TITLE
Fix: global nav hidden on /embed-anywhere page

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -8,7 +8,7 @@ export function Navigation() {
   const pathname = usePathname();
   const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null);
 
-  const isEmbed = pathname?.startsWith('/embed') ?? false;
+  const isEmbed = pathname === '/embed' || (pathname?.startsWith('/embed/') ?? false);
 
   useEffect(() => {
     if (isEmbed) return;


### PR DESCRIPTION
## Summary
- `components/Navigation.tsx` hid the global header (logo, Sign In/Dashboard) on any path with the prefix `/embed`, which unintentionally matched `/embed-anywhere` as well as the actual `/embed/[shareToken]` iframe routes
- Scoped the check to only the real embed iframe routes so `/embed-anywhere` now gets the same constant header as the rest of the site

## Test plan
- [x] Verified in browser: `/embed-anywhere` now shows the standard header above its own breadcrumb
- [x] Verified `/embed/[token]` iframe routes still correctly suppress the header