### PR TITLE
fix: release workflow on every push to main, not just merge commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # Only run if the push is a merge from develop (not direct commits)
-    if: contains(github.event.head_commit.message, 'Merge pull request') || contains(github.event.head_commit.message, 'develop')
-    
+
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,36 +35,75 @@ jobs:
 
       - name: Generate changelog
         id: changelog
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "## What's Changed" > changelog.md
-          echo "" >> changelog.md
-          
           # Get commits since last tag (or all commits if no tag)
           if [ -n "${{ steps.previous_tag.outputs.tag }}" ]; then
             RANGE="${{ steps.previous_tag.outputs.tag }}..HEAD"
           else
             RANGE="HEAD"
           fi
-          
-          # Group commits by type
-          echo "### ✨ Features" >> changelog.md
-          git log $RANGE --pretty=format:"- %s (%h)" --grep="^feat" >> changelog.md || true
-          echo "" >> changelog.md
-          echo "" >> changelog.md
-          
-          echo "### 🐛 Bug Fixes" >> changelog.md
-          git log $RANGE --pretty=format:"- %s (%h)" --grep="^fix" >> changelog.md || true
-          echo "" >> changelog.md
-          echo "" >> changelog.md
-          
-          echo "### 🔧 Other Changes" >> changelog.md
-          git log $RANGE --pretty=format:"- %s (%h)" --grep="^chore\|^docs\|^refactor\|^style\|^test" >> changelog.md || true
-          echo "" >> changelog.md
-          echo "" >> changelog.md
-          
-          echo "---" >> changelog.md
-          echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.previous_tag.outputs.tag }}...${{ steps.version.outputs.version }}" >> changelog.md
-          
+
+          # For each commit in range, resolve the PR that introduced it (if any)
+          # via the commit->PRs API, so notes carry PR links/numbers/authors
+          # instead of relying on commit-message prefix discipline.
+          ENTRIES="entries.jsonl"
+          > "$ENTRIES"
+          for sha in $(git log $RANGE --pretty=format:"%H" --reverse); do
+            pr_json=$(gh api "repos/${{ github.repository }}/commits/$sha/pulls" \
+              -H "Accept: application/vnd.github+json" 2>/dev/null || echo "[]")
+            pr=$(echo "$pr_json" | jq -c '[.[] | select(.merged_at != null)] | .[0] // empty')
+
+            if [ -n "$pr" ]; then
+              echo "$pr" | jq -c --arg sha "$sha" '{
+                sha: $sha,
+                number: .number,
+                title: .title,
+                url: .html_url,
+                author: .user.login
+              }' >> "$ENTRIES"
+            else
+              subject=$(git log -1 --pretty=format:"%s" "$sha")
+              author=$(git log -1 --pretty=format:"%an" "$sha")
+              jq -nc --arg sha "$sha" --arg title "$subject" --arg author "$author" \
+                '{sha: $sha, number: null, title: $title, url: null, author: $author}' >> "$ENTRIES"
+            fi
+          done
+
+          # Dedupe by PR number (a PR can span multiple commits), keep first occurrence
+          jq -s 'unique_by(if .number then ("pr-" + (.number|tostring)) else .sha end)' "$ENTRIES" > entries.json
+
+          format_entry() {
+            jq -r 'if .url then "- " + .title + " ([#" + (.number|tostring) + "](" + .url + ") by @" + .author + ")"
+                   else "- " + .title + " (" + (.sha[0:7]) + ")"
+                   end'
+          }
+
+          {
+            echo "## What's Changed"
+            echo ""
+
+            echo "### ✨ Features"
+            jq -c '.[] | select(.title | test("^feat(\\(.+\\))?:"; "i"))' entries.json | format_entry
+            echo ""
+
+            echo "### 🐛 Bug Fixes"
+            jq -c '.[] | select(.title | test("^fix(\\(.+\\))?:"; "i"))' entries.json | format_entry
+            echo ""
+
+            echo "### 🔧 Other Changes"
+            jq -c '.[] | select(.title | test("^(chore|docs|refactor|style|test)(\\(.+\\))?:"; "i"))' entries.json | format_entry
+            echo ""
+
+            echo "### 📦 Uncategorized"
+            jq -c '.[] | select(.title | test("^(feat|fix|chore|docs|refactor|style|test)(\\(.+\\))?:"; "i") | not)' entries.json | format_entry
+            echo ""
+
+            echo "---"
+            echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.previous_tag.outputs.tag }}...${{ steps.version.outputs.version }}"
+          } > changelog.md
+
           # Output for the release
           cat changelog.md
 


### PR DESCRIPTION
## Summary
- Removes the `if:` gate on the release workflow that only fired when the head commit message contained literally "Merge pull request" or "develop"
- Since this repo squash-merges PRs (commit message = PR title, e.g. `fix: ...`), that gate never matched — every push to `main` since 2026-06-12 silently skipped release creation (38+ commits across 15 merged PRs, zero releases cut)
- Now releases run on every push to `main`, matching how merges actually happen here

## Test plan
- [ ] Merge this PR and confirm the `Create Release` workflow run completes and a new `vYYYY.MM.DD-<sha>` tag/release is created