### PR TITLE
chore: set up Dependabot for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` enabling weekly Dependabot version updates for npm dependencies and GitHub Actions
- Minor and patch npm bumps are grouped into a single weekly PR to reduce noise; majors get individual PRs
- PR limit capped at 5 open Dependabot PRs at a time

## Notes
- Dependabot **security** alerts/updates are enabled separately in repo Settings → Advanced Security (no config file needed)
- Existing CI (`test.yml`) will run against each Dependabot PR automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)