### PR TITLE
fix: enable ISR on shared shelf page with generateStaticParams

### DIFF
--- a/app/s/[shareToken]/page.tsx
+++ b/app/s/[shareToken]/page.tsx
@@ -10,6 +10,13 @@ import { generateShelfSchemaJson } from '@/lib/utils/schemaMarkup';
 // Mutations trigger immediate refreshes via revalidateSharedShelf().
 export const revalidate = 300;
 
+// Without generateStaticParams a dynamic route is always rendered on demand
+// and `revalidate` is ignored. Returning [] pre-builds nothing but opts every
+// visited token into on-demand static generation + caching (ISR).
+export async function generateStaticParams(): Promise<{ shareToken: string }[]> {
+  return [];
+}
+
 // Dedupe queries shared by generateMetadata and the page render
 const getCachedShelf = cache(getShelfByShareToken);
 const getCachedItems = cache(getItemsByShelfId);


### PR DESCRIPTION
## Summary

Follow-up to #195. Measuring production showed the shared shelf page was still fully dynamic (`x-vercel-cache: MISS`, `cache-control: no-store`) — the embed API caching from #195 works, but `revalidate = 300` alone doesn't enable ISR on a dynamic route.

**Root cause:** a dynamic segment without `generateStaticParams` is always rendered on demand; the `revalidate` export is ignored. Adding `generateStaticParams` returning `[]` pre-builds nothing, but opts every visited share token into on-demand static generation + caching.

**Proof:** build output flips `/s/[shareToken]` from `ƒ` (Dynamic) to `●` (SSG/ISR).

## Testing

- Production build shows the route as `●` with ISR
- Page renders correctly against a live shelf in dev preview
- All 662 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)