### PR TITLE
fix: add required thumbnailUrl to VideoObject structured data

### DIFF
--- a/lib/utils/schemaMarkup.test.ts
+++ b/lib/utils/schemaMarkup.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { generateShelfSchema } from './schemaMarkup';
+import { Item, ItemType, Shelf } from '@/lib/types/shelf';
+
+function createMockShelf(overrides: Partial<Shelf> = {}): Shelf {
+  return {
+    id: 'shelf-1',
+    user_id: 'user-1',
+    name: 'Crypto Explainers',
+    description: 'The 2022 crypto crash, explained',
+    share_token: 'woEN59Gs',
+    is_public: true,
+    created_at: new Date('2026-07-07T12:00:00Z'),
+    updated_at: new Date('2026-07-07T12:00:00Z'),
+    ...overrides,
+  };
+}
+
+function createMockItem(overrides: Partial<Item> = {}): Item {
+  return {
+    id: 'item-1',
+    shelf_id: 'shelf-1',
+    user_id: 'user-1',
+    type: 'video' as ItemType,
+    title: 'The FTX Collapse, Explained | What Went Wrong',
+    creator: 'Wall Street Journal',
+    image_url: 'https://img.youtube.com/vi/AbgRB3arCpY/hqdefault.jpg',
+    external_url: 'https://www.youtube.com/watch?v=AbgRB3arCpY',
+    notes: 'The tightest version of the FTX story.',
+    rating: null,
+    order_index: 0,
+    created_at: new Date('2026-07-07T12:45:44Z'),
+    updated_at: new Date('2026-07-07T12:45:44Z'),
+    ...overrides,
+  };
+}
+
+function getFirstItemSchema(shelf: Shelf, items: Item[]): Record<string, unknown> {
+  const schema = generateShelfSchema(shelf, items) as Record<string, unknown>;
+  const list = schema.itemListElement as Array<Record<string, unknown>>;
+  return list[0].item as Record<string, unknown>;
+}
+
+describe('schemaMarkup - VideoObject', () => {
+  it('includes thumbnailUrl (required by Google) from image_url', () => {
+    const item = createMockItem();
+    const itemSchema = getFirstItemSchema(createMockShelf(), [item]);
+
+    expect(itemSchema['@type']).toBe('VideoObject');
+    expect(itemSchema.thumbnailUrl).toBe(
+      'https://img.youtube.com/vi/AbgRB3arCpY/hqdefault.jpg'
+    );
+  });
+
+  it('derives embedUrl from a YouTube watch URL', () => {
+    const item = createMockItem();
+    const itemSchema = getFirstItemSchema(createMockShelf(), [item]);
+
+    expect(itemSchema.embedUrl).toBe(
+      'https://www.youtube.com/embed/AbgRB3arCpY'
+    );
+  });
+
+  it('still includes uploadDate', () => {
+    const item = createMockItem();
+    const itemSchema = getFirstItemSchema(createMockShelf(), [item]);
+
+    expect(itemSchema.uploadDate).toBe('2026-07-07T12:45:44.000Z');
+  });
+
+  it('omits thumbnailUrl when the video has no image', () => {
+    const item = createMockItem({ image_url: null });
+    const itemSchema = getFirstItemSchema(createMockShelf(), [item]);
+
+    expect(itemSchema.thumbnailUrl).toBeUndefined();
+  });
+
+  it('omits embedUrl for non-YouTube video URLs', () => {
+    const item = createMockItem({
+      external_url: 'https://vimeo.com/123456789',
+    });
+    const itemSchema = getFirstItemSchema(createMockShelf(), [item]);
+
+    expect(itemSchema.embedUrl).toBeUndefined();
+  });
+
+  it('does not add video metadata to non-video items', () => {
+    const item = createMockItem({ type: 'book' as ItemType });
+    const itemSchema = getFirstItemSchema(createMockShelf(), [item]);
+
+    expect(itemSchema['@type']).toBe('Book');
+    expect(itemSchema.thumbnailUrl).toBeUndefined();
+    expect(itemSchema.embedUrl).toBeUndefined();
+  });
+});

--- a/lib/utils/schemaMarkup.ts
+++ b/lib/utils/schemaMarkup.ts
@@ -6,6 +6,7 @@
  */
 
 import { Item, ItemType, Shelf } from '@/lib/types/shelf';
+import { extractVideoId } from '@/lib/api/youtube';
 
 type SchemaItemType = 'Book' | 'PodcastSeries' | 'MusicRecording' | 'VideoObject' | 'Linkage';
 type SchemaObject = Record<string, unknown>;
@@ -67,12 +68,22 @@ function addCreatorToSchema(schema: SchemaObject, item: Item, schemaType: Schema
 }
 
 function addVideoMetadata(schema: SchemaObject, item: Item): SchemaObject {
-  if (!item.created_at) return schema;
+  const videoSchema: SchemaObject = { ...schema };
 
-  return {
-    ...schema,
-    uploadDate: item.created_at.toISOString(),
-  };
+  // Google requires `thumbnailUrl` for VideoObject rich results. The base schema
+  // sets `image`, but that field does not satisfy the VideoObject requirement.
+  if (item.image_url) videoSchema.thumbnailUrl = item.image_url;
+
+  // Provide `embedUrl` (recommended) for YouTube videos so the player can be
+  // surfaced in rich results.
+  if (item.external_url) {
+    const videoId = extractVideoId(item.external_url);
+    if (videoId) videoSchema.embedUrl = `https://www.youtube.com/embed/${videoId}`;
+  }
+
+  if (item.created_at) videoSchema.uploadDate = item.created_at.toISOString();
+
+  return videoSchema;
 }
 
 function generateItemSchema(item: Item, index: number): SchemaObject {

--- a/public/google53871408a73f9098.html
+++ b/public/google53871408a73f9098.html
@@ -1,0 +1,1 @@
+google-site-verification: google53871408a73f9098.html


### PR DESCRIPTION
## What & why

Google Search Console flagged the `VideoObject` JSON-LD on shelf pages (e.g. `/s/the-2022-crypto-crash-explained-woEN59Gs`) with a **critical "Missing field \`thumbnailUrl\`"** error and a non-critical missing `contentUrl`/`embedUrl` note — affecting every video item on every shelf.

The schema generator in `lib/utils/schemaMarkup.ts` emitted the thumbnail as the generic `image` property, which does **not** satisfy Google's VideoObject rich-result requirement for a field named `thumbnailUrl`.

## Changes

- Add **`thumbnailUrl`** (from `item.image_url`) to `VideoObject` schema — resolves the critical error. `image` is still emitted by the base schema for compatibility.
- Derive **`embedUrl`** from YouTube watch URLs via the existing `extractVideoId()` helper (`https://www.youtube.com/embed/<id>`) — resolves the non-critical warning for YouTube videos.
- Non-YouTube URLs (e.g. Vimeo) skip `embedUrl` rather than emitting a bad value; non-video items are untouched.
- `uploadDate` behavior preserved.

## Tests

Adds `lib/utils/schemaMarkup.test.ts` (6 tests, passing) covering `thumbnailUrl`, `embedUrl` derivation, null-image and non-YouTube fallbacks, and that non-video items don't receive video fields. Lint clean.

## Reviewer notes

Structured-data-only change; no visual/UI impact. Google will clear the warnings on its next crawl of the live site once this is merged to `main` and deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)