### PR TITLE
fix: add H1 tag to login and signup pages (#207)

### DIFF
--- a/app/login/LoginClient.tsx
+++ b/app/login/LoginClient.tsx
@@ -105,7 +105,7 @@ export default function LoginClient() {
           <Link href="/" className="text-2xl font-bold text-gray-900 dark:text-gray-100">
             Virtual Bookshelf
           </Link>
-          <p className="mt-2 text-gray-600 dark:text-gray-400">Sign in to your account</p>
+          <h1 className="mt-2 text-gray-600 dark:text-gray-400">Sign in to your Virtual Bookshelf account</h1>
         </div>
 
         <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm p-8">

--- a/app/signup/SignupClient.tsx
+++ b/app/signup/SignupClient.tsx
@@ -138,7 +138,7 @@ export default function SignupClient() {
           <Link href="/" className="text-2xl font-bold text-gray-900 dark:text-gray-100">
             Virtual Bookshelf
           </Link>
-          <p className="mt-2 text-gray-600 dark:text-gray-400">Create your account</p>
+          <h1 className="mt-2 text-gray-600 dark:text-gray-400">Create your Virtual Bookshelf account</h1>
         </div>
 
         <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm p-8">


### PR DESCRIPTION
## Summary
Fixes the Bing/Microsoft Site Scan NOTICE flagging a missing `<h1>` on `/login` and `/signup`.

Both auth pages rendered the brand name as a styled `<Link>` and a descriptive `<p>` subtitle, but no semantic `<h1>`. This promotes the subtitle to a keyword-rich `<h1>`:
- **Login:** "Sign in to your Virtual Bookshelf account"
- **Signup:** "Create your Virtual Bookshelf account"

Tailwind's preflight resets heading font-size/weight, so the rendered pages are **visually identical** (verified: h1 renders at 14px / weight 400, same as the prior `<p>`).

## Verification
- Confirmed both pages now serve the `<h1>` in server-rendered HTML (what Bingbot scans).
- `npm run lint` passes.
- Screenshot confirms unchanged layout.

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)