### PR TITLE
fix(seo): shorten /embed-anywhere title under 70 characters

### DIFF
--- a/app/embed-anywhere/page.tsx
+++ b/app/embed-anywhere/page.tsx
@@ -6,7 +6,7 @@ import { faqPageJsonLd, breadcrumbJsonLd, type FaqItem } from '@/lib/utils/landi
 const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.app';
 
 export const metadata: Metadata = {
-  title: 'Embed a Shelf in Your Newsletter, Email, or Website — Virtual Bookshelf',
+  title: 'Embed a Shelf in a Newsletter, Email, or Website — Virtual Bookshelf',
   description:
     'Embed a live, clickable resource shelf directly in a newsletter, email, or website. One snippet, always up to date — no screenshots, no broken link lists.',
   alternates: { canonical: '/embed-anywhere' },


### PR DESCRIPTION
## Summary
The `/embed-anywhere` page title tag was **71 characters**, which a site scan flagged as too long — search engines may truncate or ignore titles over 70 chars.

**Before (71):** `Embed a Shelf in Your Newsletter, Email, or Website — Virtual Bookshelf`
**After (68):** `Embed a Shelf in a Newsletter, Email, or Website — Virtual Bookshelf`

Swapped "Your" → "a". Keeps all target keywords (newsletter/email/website) and the `— Virtual Bookshelf` brand suffix, consistent with sibling landing pages.

## Test plan
- Character count verified at 68 (under the 70-char limit).
- Single-line `metadata.title` string change; no runtime logic affected.

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)