### PR TITLE
fix: resolve GSC "Video isn't on a watch page" with dedicated /v/[videoId] pages

### DIFF
--- a/app/s/[shareToken]/SharedShelfInteractive.tsx
+++ b/app/s/[shareToken]/SharedShelfInteractive.tsx
@@ -27,12 +27,21 @@ export function SharedShelfInteractive({ items, children }: SharedShelfInteracti
     (e: React.MouseEvent<HTMLDivElement>) => {
       // Find the closest item card element
       const itemCard = (e.target as HTMLElement).closest('[data-item-id]');
-      if (itemCard) {
-        const itemId = itemCard.getAttribute('data-item-id');
-        const item = items.find((i) => i.id === itemId);
-        if (item) {
-          setSelectedItem(item);
-        }
+      if (!itemCard) return;
+
+      // Video cards contain a real <a> to their /v/[videoId] watch page.
+      // Let modified clicks (cmd/ctrl/shift/alt) follow the link so users can
+      // open the watch page in a new tab; a plain click keeps the modal UX.
+      const isModifiedClick = e.metaKey || e.ctrlKey || e.shiftKey || e.altKey;
+      if (isModifiedClick && (e.target as HTMLElement).closest('a')) {
+        return;
+      }
+      e.preventDefault();
+
+      const itemId = itemCard.getAttribute('data-item-id');
+      const item = items.find((i) => i.id === itemId);
+      if (item) {
+        setSelectedItem(item);
       }
     },
     [items]

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,18 +1,41 @@
 import { MetadataRoute } from 'next'
-import { getPublicShelves } from '@/lib/db/queries'
+import { getPublicShelves, getPublicVideoItems } from '@/lib/db/queries'
 import { buildSharePath } from '@/lib/utils/slug'
+import { extractVideoId } from '@/lib/api/youtube'
 
 export const dynamic = 'force-dynamic'
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.app'
-  const shelves = await getPublicShelves()
+  const [shelves, videoItems] = await Promise.all([
+    getPublicShelves(),
+    getPublicVideoItems(),
+  ])
 
   const shelfUrls = shelves.map(shelf => ({
     url: `${baseUrl}${buildSharePath(shelf.name, shelf.share_token)}`,
     lastModified: shelf.updated_at,
     changeFrequency: 'weekly' as const,
     priority: 0.8,
+  }))
+
+  // One canonical /v/[videoId] entry per video; keep the most recent
+  // lastModified when the same video appears on multiple public shelves.
+  const videoLastModified = new Map<string, Date>()
+  for (const { external_url, updated_at } of videoItems) {
+    const videoId = external_url ? extractVideoId(external_url) : null
+    if (!videoId) continue
+    const existing = videoLastModified.get(videoId)
+    if (!existing || updated_at > existing) {
+      videoLastModified.set(videoId, updated_at)
+    }
+  }
+
+  const videoUrls = Array.from(videoLastModified.entries()).map(([videoId, lastModified]) => ({
+    url: `${baseUrl}/v/${videoId}`,
+    lastModified,
+    changeFrequency: 'monthly' as const,
+    priority: 0.6,
   }))
 
   return [
@@ -25,5 +48,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${baseUrl}/curate-conference-resources`, changeFrequency: 'monthly', priority: 0.9 },
     { url: `${baseUrl}/embed-anywhere`, changeFrequency: 'monthly', priority: 0.9 },
     ...shelfUrls,
+    ...videoUrls,
   ]
 }

--- a/app/v/[videoId]/page.tsx
+++ b/app/v/[videoId]/page.tsx
@@ -1,0 +1,155 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { getPublicVideoByVideoId } from '@/lib/db/queries';
+import {
+  isValidVideoId,
+  getEmbedUrl,
+  getWatchUrl,
+  getThumbnailUrl,
+} from '@/lib/api/youtube';
+import { generateVideoObjectSchemaJson } from '@/lib/utils/schemaMarkup';
+import { buildSharePath } from '@/lib/utils/slug';
+
+interface PageProps {
+  params: Promise<{ videoId: string }>;
+}
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://virtualbookshelf.app';
+
+/**
+ * Dedicated video watch page — /v/[videoId]
+ *
+ * Unlike the shelf collection page, a single video is the main, embedded,
+ * playable content here. The YouTube player is rendered directly into the
+ * server HTML (not behind a modal), and the page carries full VideoObject
+ * structured data, so Google can index it as a real "watch page" and surface
+ * it in video results. See lib/utils/schemaMarkup.ts for the schema rationale.
+ */
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { videoId } = await params;
+
+  if (!isValidVideoId(videoId)) {
+    return { title: 'Video Not Found | Virtual Bookshelf' };
+  }
+
+  const result = await getPublicVideoByVideoId(videoId);
+  if (!result) {
+    return { title: 'Video Not Found | Virtual Bookshelf' };
+  }
+
+  const { item, shelfName } = result;
+  const description = item.notes
+    ? item.notes.substring(0, 155)
+    : `${item.title}${item.creator ? ` by ${item.creator}` : ''} — from the "${shelfName}" shelf on Virtual Bookshelf.`;
+  const canonical = `${BASE_URL}/v/${videoId}`;
+  const thumbnailUrl = item.image_url || getThumbnailUrl(videoId);
+
+  return {
+    title: `${item.title} | Virtual Bookshelf`,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title: item.title,
+      description,
+      type: 'video.other',
+      url: canonical,
+      images: [{ url: thumbnailUrl, alt: item.title }],
+      siteName: 'Virtual Bookshelf',
+    },
+    twitter: {
+      card: 'player',
+      title: item.title,
+      description,
+      images: [thumbnailUrl],
+    },
+  };
+}
+
+export default async function VideoWatchPage({ params }: PageProps) {
+  const { videoId } = await params;
+
+  if (!isValidVideoId(videoId)) {
+    notFound();
+  }
+
+  const result = await getPublicVideoByVideoId(videoId);
+  if (!result) {
+    notFound();
+  }
+
+  const { item, shelfName, shelfShareToken } = result;
+  const embedUrl = getEmbedUrl(videoId);
+  const contentUrl = getWatchUrl(videoId);
+  const thumbnailUrl = item.image_url || getThumbnailUrl(videoId);
+
+  const schemaJson = generateVideoObjectSchemaJson(item, {
+    embedUrl,
+    contentUrl,
+    thumbnailUrl,
+  });
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: schemaJson }}
+        suppressHydrationWarning
+      />
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          {/* Embedded player — the main content, in server HTML for crawlers */}
+          <div className="relative w-full overflow-hidden rounded-xl bg-black shadow-lg" style={{ aspectRatio: '16 / 9' }}>
+            <iframe
+              className="absolute inset-0 h-full w-full"
+              src={embedUrl}
+              title={item.title}
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              allowFullScreen
+              loading="lazy"
+            />
+          </div>
+
+          {/* Metadata */}
+          <div className="mt-6">
+            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100">
+              {item.title}
+            </h1>
+            {item.creator && (
+              <p className="mt-1 text-gray-600 dark:text-gray-400">{item.creator}</p>
+            )}
+
+            {item.notes && (
+              <p className="mt-4 whitespace-pre-line text-gray-700 dark:text-gray-300 leading-relaxed">
+                {item.notes}
+              </p>
+            )}
+
+            {/* Backlink into the collection it belongs to */}
+            <div className="mt-8 border-t border-gray-200 dark:border-gray-800 pt-6">
+              <Link
+                href={buildSharePath(shelfName, shelfShareToken)}
+                className="inline-flex items-center gap-2 text-sm font-medium text-blue-700 dark:text-blue-300 hover:underline"
+              >
+                <span aria-hidden>←</span>
+                From the &ldquo;{shelfName}&rdquo; shelf
+              </Link>
+            </div>
+
+            {/* Direct link to source */}
+            <div className="mt-4">
+              <a
+                href={contentUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-gray-500 dark:text-gray-400 hover:underline"
+              >
+                Watch on YouTube ↗
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/shelf/ItemCardStatic.tsx
+++ b/components/shelf/ItemCardStatic.tsx
@@ -8,10 +8,12 @@
  * No onClick handlers - interactivity handled by parent client component
  */
 
+import Link from 'next/link';
 import { Item } from '@/lib/types/shelf';
 import { getAspectRatio, getAspectRatioNumeric } from '@/lib/constants/aspectRatios';
 import { StarDisplayStatic } from '@/components/ui/StarDisplayStatic';
 import { calculateJitter } from '@/lib/utils/imageUtils';
+import { extractVideoId } from '@/lib/api/youtube';
 
 interface ItemCardStaticProps {
   item: Item;
@@ -28,6 +30,12 @@ export function ItemCardStatic({ item, ...props }: ItemCardStaticProps) {
     : item.image_url;
   const adjustedRatioNum = baseRatioNum * (1 + jitter);
   const hasNotes = Boolean(item.notes);
+
+  // Video items get a crawlable link to their dedicated /v/[videoId] watch
+  // page. A plain click still opens the modal (SharedShelfInteractive calls
+  // preventDefault); the href exists for crawlers and cmd/middle-click.
+  const videoId = item.type === 'video' && item.external_url ? extractVideoId(item.external_url) : null;
+  const watchHref = videoId ? `/v/${videoId}` : null;
 
   const badgeColor = {
     book: 'bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200',
@@ -85,6 +93,17 @@ export function ItemCardStatic({ item, ...props }: ItemCardStaticProps) {
             {item.type}
           </span>
         </div>
+
+        {/* Crawlable link to the dedicated watch page for video items.
+            Overlay so it doesn't disturb card layout; a plain click is
+            intercepted by SharedShelfInteractive to open the modal instead. */}
+        {watchHref && (
+          <Link
+            href={watchHref}
+            className="absolute inset-0 z-10"
+            aria-label={`Watch ${item.title}`}
+          />
+        )}
       </div>
 
       {/* Item Metadata - visible to crawlers */}

--- a/lib/api/youtube.ts
+++ b/lib/api/youtube.ts
@@ -56,6 +56,31 @@ export function extractVideoId(url: string): string | null {
 }
 
 /**
+ * Canonical YouTube URLs derived from a video ID. Used for VideoObject
+ * structured data (embedUrl / contentUrl / thumbnailUrl) and the embedded
+ * player on the /v/[videoId] watch page.
+ */
+export function getEmbedUrl(videoId: string): string {
+  return `https://www.youtube.com/embed/${videoId}`;
+}
+
+export function getWatchUrl(videoId: string): string {
+  return `https://www.youtube.com/watch?v=${videoId}`;
+}
+
+export function getThumbnailUrl(videoId: string): string {
+  return `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
+}
+
+/**
+ * Whether a string looks like a valid YouTube video ID (11 chars, URL-safe
+ * base64 alphabet). Guards the /v/[videoId] route against junk lookups.
+ */
+export function isValidVideoId(videoId: string): boolean {
+  return /^[A-Za-z0-9_-]{11}$/.test(videoId);
+}
+
+/**
  * Fetch video metadata from YouTube Data API v3
  * This uses the Videos.list endpoint which costs 1 quota unit
  */

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -1,6 +1,7 @@
 import { sql, sqlQuery } from './client';
 import { User, Item, Shelf, CreateItemData, UpdateItemData, ShelfWithItems, DashboardShelf, ShelfPreviewItem, OAuthClient, OAuthAuthorizationCode, OAuthAccessToken } from '../types/shelf';
 import { generateShortToken } from '../utils/token';
+import { extractVideoId } from '../api/youtube';
 
 // ============================================================================
 // DYNAMIC UPDATE HELPER
@@ -521,6 +522,70 @@ export async function getItemById(itemId: string): Promise<Item | null> {
   `;
 
   return result.length > 0 ? (result[0] as Item) : null;
+}
+
+/**
+ * A public video item together with the public shelf it belongs to.
+ * Backs the /v/[videoId] watch page.
+ */
+export interface PublicVideo {
+  item: Item;
+  shelfName: string;
+  shelfShareToken: string;
+}
+
+/**
+ * Find a public video item by its YouTube video ID.
+ *
+ * `external_url` stores the full watch URL in varying formats (watch?v=,
+ * youtu.be/, /embed/, /shorts/), so we narrow with a substring match in SQL
+ * and confirm the exact ID in JS via extractVideoId to avoid false positives
+ * (e.g. the ID appearing inside an unrelated query param). If the same video
+ * lives on multiple public shelves, the earliest-added one wins so the
+ * canonical watch page is stable.
+ */
+export async function getPublicVideoByVideoId(videoId: string): Promise<PublicVideo | null> {
+  const rows = await sql`
+    SELECT
+      i.*,
+      s.name AS shelf_name,
+      s.share_token AS shelf_share_token
+    FROM items i
+    JOIN shelves s ON s.id = i.shelf_id
+    WHERE i.type = 'video'
+      AND s.is_public = true
+      AND i.external_url LIKE ${'%' + videoId + '%'}
+    ORDER BY i.created_at ASC
+  `;
+
+  for (const row of rows as (Item & { shelf_name: string; shelf_share_token: string })[]) {
+    if (row.external_url && extractVideoId(row.external_url) === videoId) {
+      const { shelf_name, shelf_share_token, ...item } = row;
+      return {
+        item: item as Item,
+        shelfName: shelf_name,
+        shelfShareToken: shelf_share_token,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * All public video items, for building /v/[videoId] sitemap entries.
+ * Returns the raw external_url + updated_at; callers derive/dedupe video IDs.
+ */
+export async function getPublicVideoItems(): Promise<{ external_url: string | null; updated_at: Date }[]> {
+  const result = await sql`
+    SELECT i.external_url, i.updated_at
+    FROM items i
+    JOIN shelves s ON s.id = i.shelf_id
+    WHERE i.type = 'video' AND s.is_public = true
+    ORDER BY i.updated_at DESC
+  `;
+
+  return result as { external_url: string | null; updated_at: Date }[];
 }
 
 const ITEM_UPDATABLE_FIELDS = [

--- a/lib/utils/schemaMarkup.test.ts
+++ b/lib/utils/schemaMarkup.test.ts
@@ -1,38 +1,41 @@
 import { describe, it, expect } from 'vitest';
-import { generateShelfSchema } from './schemaMarkup';
+import {
+  generateShelfSchema,
+  generateVideoObjectSchema,
+} from './schemaMarkup';
 import { Item, ItemType, Shelf } from '@/lib/types/shelf';
-
-function createMockShelf(overrides: Partial<Shelf> = {}): Shelf {
-  return {
-    id: 'shelf-1',
-    user_id: 'user-1',
-    name: 'Crypto Explainers',
-    description: 'The 2022 crypto crash, explained',
-    share_token: 'woEN59Gs',
-    is_public: true,
-    created_at: new Date('2026-07-07T12:00:00Z'),
-    updated_at: new Date('2026-07-07T12:00:00Z'),
-    ...overrides,
-  };
-}
 
 function createMockItem(overrides: Partial<Item> = {}): Item {
   return {
     id: 'item-1',
     shelf_id: 'shelf-1',
     user_id: 'user-1',
-    type: 'video' as ItemType,
-    title: 'The FTX Collapse, Explained | What Went Wrong',
-    creator: 'Wall Street Journal',
-    image_url: 'https://img.youtube.com/vi/AbgRB3arCpY/hqdefault.jpg',
-    external_url: 'https://www.youtube.com/watch?v=AbgRB3arCpY',
-    notes: 'The tightest version of the FTX story.',
+    type: 'video',
+    title: 'The 2022 Crypto Crash, Explained',
+    creator: 'Some Channel',
+    image_url: 'https://example.com/thumb.jpg',
+    external_url: 'https://www.youtube.com/watch?v=woEN59Gs123',
+    notes: 'A great explainer',
     rating: null,
     order_index: 0,
-    created_at: new Date('2026-07-07T12:45:44Z'),
-    updated_at: new Date('2026-07-07T12:45:44Z'),
+    created_at: new Date('2026-01-15T00:00:00Z'),
+    updated_at: new Date('2026-01-15T00:00:00Z'),
     ...overrides,
   };
+}
+
+function createMockShelf(overrides: Partial<Shelf> = {}): Shelf {
+  return {
+    id: 'shelf-1',
+    user_id: 'user-1',
+    name: 'My Shelf',
+    description: 'A shelf',
+    share_token: 'my-shelf-abc',
+    is_public: true,
+    created_at: new Date('2026-01-01T00:00:00Z'),
+    updated_at: new Date('2026-01-10T00:00:00Z'),
+    ...overrides,
+  } as Shelf;
 }
 
 function getFirstItemSchema(shelf: Shelf, items: Item[]): Record<string, unknown> {
@@ -41,55 +44,68 @@ function getFirstItemSchema(shelf: Shelf, items: Item[]): Record<string, unknown
   return list[0].item as Record<string, unknown>;
 }
 
-describe('schemaMarkup - VideoObject', () => {
-  it('includes thumbnailUrl (required by Google) from image_url', () => {
+describe('generateShelfSchema (collection page)', () => {
+  it('serializes video items as CreativeWork, never VideoObject', () => {
+    const shelf = createMockShelf();
+    const items = [createMockItem()];
+    const schema = generateShelfSchema(shelf, items, 'user');
+
+    const listItem = (schema.itemListElement as Record<string, unknown>[])[0];
+    const inner = listItem.item as Record<string, unknown>;
+
+    expect(inner['@type']).toBe('CreativeWork');
+    // The whole collection must not claim VideoObject anywhere — that's what
+    // triggered "Video isn't on a watch page" in Search Console. VideoObject
+    // now lives only on the dedicated /v/[videoId] watch pages.
+    expect(JSON.stringify(schema)).not.toContain('VideoObject');
+  });
+
+  it('uses dateCreated (not the VideoObject-only uploadDate) for video items', () => {
     const item = createMockItem();
-    const itemSchema = getFirstItemSchema(createMockShelf(), [item]);
+    const inner = getFirstItemSchema(createMockShelf(), [item]);
 
-    expect(itemSchema['@type']).toBe('VideoObject');
-    expect(itemSchema.thumbnailUrl).toBe(
-      'https://img.youtube.com/vi/AbgRB3arCpY/hqdefault.jpg'
-    );
-  });
-
-  it('derives embedUrl from a YouTube watch URL', () => {
-    const item = createMockItem();
-    const itemSchema = getFirstItemSchema(createMockShelf(), [item]);
-
-    expect(itemSchema.embedUrl).toBe(
-      'https://www.youtube.com/embed/AbgRB3arCpY'
-    );
-  });
-
-  it('still includes uploadDate', () => {
-    const item = createMockItem();
-    const itemSchema = getFirstItemSchema(createMockShelf(), [item]);
-
-    expect(itemSchema.uploadDate).toBe('2026-07-07T12:45:44.000Z');
-  });
-
-  it('omits thumbnailUrl when the video has no image', () => {
-    const item = createMockItem({ image_url: null });
-    const itemSchema = getFirstItemSchema(createMockShelf(), [item]);
-
-    expect(itemSchema.thumbnailUrl).toBeUndefined();
-  });
-
-  it('omits embedUrl for non-YouTube video URLs', () => {
-    const item = createMockItem({
-      external_url: 'https://vimeo.com/123456789',
-    });
-    const itemSchema = getFirstItemSchema(createMockShelf(), [item]);
-
-    expect(itemSchema.embedUrl).toBeUndefined();
+    expect(inner.dateCreated).toBe(item.created_at.toISOString());
+    expect(inner.uploadDate).toBeUndefined();
   });
 
   it('does not add video metadata to non-video items', () => {
     const item = createMockItem({ type: 'book' as ItemType });
-    const itemSchema = getFirstItemSchema(createMockShelf(), [item]);
+    const inner = getFirstItemSchema(createMockShelf(), [item]);
 
-    expect(itemSchema['@type']).toBe('Book');
-    expect(itemSchema.thumbnailUrl).toBeUndefined();
-    expect(itemSchema.embedUrl).toBeUndefined();
+    expect(inner['@type']).toBe('Book');
+    expect(inner.dateCreated).toBeUndefined();
+  });
+});
+
+describe('generateVideoObjectSchema (watch page)', () => {
+  const opts = {
+    embedUrl: 'https://www.youtube.com/embed/woEN59Gs123',
+    contentUrl: 'https://www.youtube.com/watch?v=woEN59Gs123',
+    thumbnailUrl: 'https://img.youtube.com/vi/woEN59Gs123/hqdefault.jpg',
+  };
+
+  it('emits a VideoObject with all Google-required fields', () => {
+    const item = createMockItem();
+    const schema = generateVideoObjectSchema(item, opts);
+
+    expect(schema['@type']).toBe('VideoObject');
+    expect(schema.name).toBe(item.title);
+    expect(schema.thumbnailUrl).toBe(opts.thumbnailUrl);
+    expect(schema.uploadDate).toBe(item.created_at.toISOString());
+    expect(schema.embedUrl).toBe(opts.embedUrl);
+    expect(schema.contentUrl).toBe(opts.contentUrl);
+  });
+
+  it('includes description and creator when present, omits when absent', () => {
+    const withMeta = generateVideoObjectSchema(createMockItem(), opts);
+    expect(withMeta.description).toBe('A great explainer');
+    expect(withMeta.creator).toMatchObject({ '@type': 'Person', name: 'Some Channel' });
+
+    const withoutMeta = generateVideoObjectSchema(
+      createMockItem({ notes: null, creator: '' }),
+      opts
+    );
+    expect(withoutMeta.description).toBeUndefined();
+    expect(withoutMeta.creator).toBeUndefined();
   });
 });

--- a/lib/utils/schemaMarkup.ts
+++ b/lib/utils/schemaMarkup.ts
@@ -6,17 +6,23 @@
  */
 
 import { Item, ItemType, Shelf } from '@/lib/types/shelf';
-import { extractVideoId } from '@/lib/api/youtube';
 
-type SchemaItemType = 'Book' | 'PodcastSeries' | 'MusicRecording' | 'VideoObject' | 'Linkage';
+type SchemaItemType = 'Book' | 'PodcastSeries' | 'MusicRecording' | 'CreativeWork' | 'Linkage';
 type SchemaObject = Record<string, unknown>;
 
+// Note: video items use 'CreativeWork', not 'VideoObject'. A shelf is a
+// collection (ItemList) of many items, not a video "watch page" where a single
+// video is the main, playable content. Declaring VideoObject here caused Google
+// Search Console to report "Video isn't on a watch page" for every shelf that
+// contained a video — the videos could never be indexed as video results, and
+// the warning persisted. CreativeWork describes the item honestly without
+// claiming video-indexing eligibility.
 const SCHEMA_TYPE_MAP: Record<ItemType, SchemaItemType> = {
   book: 'Book',
   podcast: 'PodcastSeries',
   podcast_episode: 'PodcastSeries',
   music: 'MusicRecording',
-  video: 'VideoObject',
+  video: 'CreativeWork',
   link: 'Linkage',
   stock: 'Linkage',
 };
@@ -25,7 +31,7 @@ const CREATOR_PROPERTY_MAP: Record<SchemaItemType, string> = {
   Book: 'author',
   MusicRecording: 'byArtist',
   PodcastSeries: 'creator',
-  VideoObject: 'creator',
+  CreativeWork: 'creator',
   Linkage: 'creator',
 };
 
@@ -68,22 +74,12 @@ function addCreatorToSchema(schema: SchemaObject, item: Item, schemaType: Schema
 }
 
 function addVideoMetadata(schema: SchemaObject, item: Item): SchemaObject {
-  const videoSchema: SchemaObject = { ...schema };
+  if (!item.created_at) return schema;
 
-  // Google requires `thumbnailUrl` for VideoObject rich results. The base schema
-  // sets `image`, but that field does not satisfy the VideoObject requirement.
-  if (item.image_url) videoSchema.thumbnailUrl = item.image_url;
-
-  // Provide `embedUrl` (recommended) for YouTube videos so the player can be
-  // surfaced in rich results.
-  if (item.external_url) {
-    const videoId = extractVideoId(item.external_url);
-    if (videoId) videoSchema.embedUrl = `https://www.youtube.com/embed/${videoId}`;
-  }
-
-  if (item.created_at) videoSchema.uploadDate = item.created_at.toISOString();
-
-  return videoSchema;
+  return {
+    ...schema,
+    dateCreated: item.created_at.toISOString(),
+  };
 }
 
 function generateItemSchema(item: Item, index: number): SchemaObject {
@@ -92,7 +88,7 @@ function generateItemSchema(item: Item, index: number): SchemaObject {
   
   schema = addCreatorToSchema(schema, item, schemaType);
   
-  if (schemaType === 'VideoObject') {
+  if (item.type === 'video') {
     schema = addVideoMetadata(schema, item);
   }
 
@@ -142,4 +138,42 @@ export function generateShelfSchemaJson(
 ): string {
   const schema = generateShelfSchema(shelf, items, username);
   return JSON.stringify(schema, null, 2);
+}
+
+/**
+ * Full VideoObject markup for a dedicated /v/[videoId] watch page.
+ *
+ * Unlike the collection page (which uses CreativeWork — see SCHEMA_TYPE_MAP),
+ * the watch page IS a real watch page: a single video that is the main,
+ * embedded, playable content. That makes VideoObject appropriate and eligible
+ * for Google video results. Required fields (name, thumbnailUrl, uploadDate)
+ * are always emitted; embedUrl/contentUrl/description are added when available.
+ */
+export function generateVideoObjectSchema(
+  item: Item,
+  opts: { embedUrl: string; contentUrl: string; thumbnailUrl: string }
+): SchemaObject {
+  const schema: SchemaObject = {
+    '@context': 'https://schema.org',
+    '@type': 'VideoObject',
+    name: item.title,
+    thumbnailUrl: opts.thumbnailUrl,
+    embedUrl: opts.embedUrl,
+    contentUrl: opts.contentUrl,
+    // Best available date: when the video was added to the shelf. Not the
+    // original YouTube upload date (not stored), but a valid required value.
+    uploadDate: item.created_at.toISOString(),
+  };
+
+  if (item.notes) schema.description = item.notes;
+  if (item.creator) schema.creator = createPersonObject(item.creator);
+
+  return schema;
+}
+
+export function generateVideoObjectSchemaJson(
+  item: Item,
+  opts: { embedUrl: string; contentUrl: string; thumbnailUrl: string }
+): string {
+  return JSON.stringify(generateVideoObjectSchema(item, opts), null, 2);
 }


### PR DESCRIPTION
## What & why

Google Search Console flagged **"Video isn't on a watch page"** for 3 shelf URLs. The `/s/[shareToken]` shelf page is a **collection** (`ItemList`), but it emitted schema.org `VideoObject` for each video item. Google only indexes videos that live on a dedicated *watch page* (a single video as the main, playable content), so these videos could never be indexed and the warning persisted.

## The fix (two parts)

1. **Collection pages stop claiming videos** — video items now serialize as `CreativeWork` instead of `VideoObject`. Honest for a curated list, and clears the GSC warning.
2. **New `/v/[videoId]` watch pages** — where the video *is* the main content:
   - Server-rendered YouTube **iframe in the initial HTML** (crawlable, not behind a modal)
   - Full **`VideoObject`** JSON-LD (`name`, `thumbnailUrl`, `embedUrl`, `contentUrl`, `uploadDate`, `description`, `creator`)
   - Self-referential canonical + OG/Twitter player metadata
   - Sitemap entries (one canonical, deduped per video)
   - Crawlable links from shelf video cards + a backlink to the source shelf

These pages become eligible for Google video results — net-new SEO surface.

## Reviewer notes

- **Shelf UX is unchanged.** A plain click on a video card still opens the modal player; the `<a href="/v/...">` is followed only on cmd/ctrl-click (new tab) and by crawlers (`SharedShelfInteractive` calls `preventDefault` on plain clicks).
- `uploadDate` uses the item's added-to-shelf date (real YouTube upload date isn't stored) — a valid required value, not exact.
- `getPublicVideoByVideoId` narrows with a SQL substring match on `external_url`, then confirms the exact ID in JS via `extractVideoId` to avoid false positives.

## Verification

- ✅ Production build compiles (`/v/[videoId]` and `/sitemap.xml` in the route manifest)
- ✅ New schema tests + existing `youtube` / `ItemCardStatic` tests pass
- ✅ tsc + eslint clean on changed files
- ⚠️ **Not** browser-verified end-to-end (no DB creds in the worktree) — worth a look on a preview deploy before merge

After deploy, hit **Validate Fix** in the GSC "Video isn't on a watch page" report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)